### PR TITLE
Seed mock data: realistic UHIDs/phone numbers and profile data; update tests

### DIFF
--- a/patients/management/commands/seed_mock_data.py
+++ b/patients/management/commands/seed_mock_data.py
@@ -19,9 +19,33 @@ from patients.models import (
 class Command(BaseCommand):
     help = "Seed mock MEDTRACK data (default 10 cases) for local demo/testing."
 
+    mock_profiles = [
+        {"first_name": "Karthik", "last_name": "Raman", "town": "Madurai", "facility_code": "MDU"},
+        {"first_name": "Nivetha", "last_name": "Sundaram", "town": "Coimbatore", "facility_code": "CBE"},
+        {"first_name": "Pradeep", "last_name": "Subramanian", "town": "Tirunelveli", "facility_code": "TVL"},
+        {"first_name": "Anitha", "last_name": "Balasubramaniam", "town": "Salem", "facility_code": "SLM"},
+        {"first_name": "Vignesh", "last_name": "Narayanan", "town": "Erode", "facility_code": "ERD"},
+        {"first_name": "Harini", "last_name": "Sivakumar", "town": "Chengalpattu", "facility_code": "CGP"},
+        {"first_name": "Sathish", "last_name": "Arumugam", "town": "Trichy", "facility_code": "TRY"},
+        {"first_name": "Meena", "last_name": "Rajendran", "town": "Thanjavur", "facility_code": "TNJ"},
+        {"first_name": "Aravind", "last_name": "Muthukumar", "town": "Vellore", "facility_code": "VLR"},
+        {"first_name": "Keerthana", "last_name": "Manikandan", "town": "Kanchipuram", "facility_code": "KPM"},
+        {"first_name": "Dinesh", "last_name": "Saravanan", "town": "Tiruppur", "facility_code": "TPR"},
+        {"first_name": "Yamini", "last_name": "Periyasamy", "town": "Nagapattinam", "facility_code": "NGP"},
+    ]
+
     def add_arguments(self, parser):
         parser.add_argument("--count", type=int, default=10)
         parser.add_argument("--reset", action="store_true", help="Delete existing case/task/activity data before seeding")
+
+    def _build_uhid(self, profile, index, today):
+        # Example: TN-MDU-260001 (state-facility-year-sequence)
+        return f"TN-{profile['facility_code']}-{today:%y}{index:04d}"
+
+    def _build_phone_number(self, index):
+        # Indian mobile-style numbers with valid starting digits 6/7/8/9.
+        start_digit = str(9 - ((index - 1) % 4))
+        return f"{start_digit}{(700000000 + index):09d}"
 
     def handle(self, *args, **options):
         count = max(options["count"], 1)
@@ -45,19 +69,20 @@ class Command(BaseCommand):
         today = timezone.localdate()
         created = 0
         for i in range(1, count + 1):
-            uhid = f"MOCK-{i:03d}"
+            profile = self.mock_profiles[(i - 1) % len(self.mock_profiles)]
+            uhid = self._build_uhid(profile, i, today)
             if Case.objects.filter(uhid=uhid).exists():
                 continue
 
             bucket = i % 3
             kwargs = {
                 "uhid": uhid,
-                "first_name": "Mock",
-                "last_name": f"Patient {i}",
-                "phone_number": f"9{i:09d}"[-10:],
+                "first_name": profile["first_name"],
+                "last_name": profile["last_name"],
+                "phone_number": self._build_phone_number(i),
                 "status": CaseStatus.ACTIVE,
                 "created_by": demo_user,
-                "notes": "Seeded demo case",
+                "notes": f"Demo follow-up case from {profile['town']} OPD with reachable caretaker contact.",
             }
 
             if bucket == 1:

--- a/patients/tests.py
+++ b/patients/tests.py
@@ -161,6 +161,12 @@ class MedtrackViewTests(TestCase):
 
 
 class SeedMockDataCommandTests(TestCase):
-    def test_seed_mock_data_creates_cases(self):
+    def test_seed_mock_data_creates_cases_with_believable_identifiers(self):
         call_command("seed_mock_data", "--count", "10", "--reset")
-        self.assertEqual(Case.objects.filter(uhid__startswith="MOCK-").count(), 10)
+
+        seeded_cases = Case.objects.filter(uhid__startswith="TN-").order_by("uhid")
+        self.assertEqual(seeded_cases.count(), 10)
+
+        for case in seeded_cases:
+            self.assertRegex(case.uhid, r"^TN-[A-Z]{3}-\d{6}$")
+            self.assertRegex(case.phone_number, r"^[6-9]\d{9}$")


### PR DESCRIPTION
### Motivation
- Improve the seeded demo data to produce more realistic and region-aware identifiers and contact numbers for local demos.
- Make seeded cases more representative by cycling through a set of mock patient profiles rather than generic "MOCK" names.

### Description
- Add a set of `mock_profiles` and use them to populate `first_name`, `last_name`, `notes`, and to derive facility codes for UHIDs in `seed_mock_data.py`.
- Implement `_build_uhid` to generate UHIDs in the form `TN-<FAC>-YYNNNN` and `_build_phone_number` to generate valid 10-digit Indian mobile numbers starting with digits 6–9.
- Replace the previous `MOCK-` UHID generation and simplistic phone formatting with the new profile-driven generators when creating `Case` objects, while retaining existing logic for bucketed categories and task generation.
- Update the test `test_seed_mock_data_creates_cases` to `test_seed_mock_data_creates_cases_with_believable_identifiers` and assert that seeded cases have UHIDs starting with `TN-` and that UHIDs and phone numbers match the expected regex patterns.

### Testing
- Ran the patients test suite with `python manage.py test patients`, which executes the updated `SeedMockDataCommandTests` and related view tests; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ef7501ba88327b76c7a3de94ac445)