### PR TITLE
Enhance seed mock data demographics and ANC gender routing

### DIFF
--- a/patients/management/commands/seed_mock_data.py
+++ b/patients/management/commands/seed_mock_data.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import date, timedelta
 
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
@@ -9,6 +9,7 @@ from patients.models import (
     CaseActivityLog,
     CaseStatus,
     DepartmentConfig,
+    Gender,
     ReviewFrequency,
     SurgicalPathway,
     build_default_tasks,
@@ -20,18 +21,18 @@ class Command(BaseCommand):
     help = "Seed mock MEDTRACK data (default 10 cases) for local demo/testing."
 
     mock_profiles = [
-        {"first_name": "Karthik", "last_name": "Raman", "town": "Madurai", "facility_code": "MDU"},
-        {"first_name": "Nivetha", "last_name": "Sundaram", "town": "Coimbatore", "facility_code": "CBE"},
-        {"first_name": "Pradeep", "last_name": "Subramanian", "town": "Tirunelveli", "facility_code": "TVL"},
-        {"first_name": "Anitha", "last_name": "Balasubramaniam", "town": "Salem", "facility_code": "SLM"},
-        {"first_name": "Vignesh", "last_name": "Narayanan", "town": "Erode", "facility_code": "ERD"},
-        {"first_name": "Harini", "last_name": "Sivakumar", "town": "Chengalpattu", "facility_code": "CGP"},
-        {"first_name": "Sathish", "last_name": "Arumugam", "town": "Trichy", "facility_code": "TRY"},
-        {"first_name": "Meena", "last_name": "Rajendran", "town": "Thanjavur", "facility_code": "TNJ"},
-        {"first_name": "Aravind", "last_name": "Muthukumar", "town": "Vellore", "facility_code": "VLR"},
-        {"first_name": "Keerthana", "last_name": "Manikandan", "town": "Kanchipuram", "facility_code": "KPM"},
-        {"first_name": "Dinesh", "last_name": "Saravanan", "town": "Tiruppur", "facility_code": "TPR"},
-        {"first_name": "Yamini", "last_name": "Periyasamy", "town": "Nagapattinam", "facility_code": "NGP"},
+        {"first_name": "Karthik", "last_name": "Raman", "place": "Madurai", "gender": Gender.MALE, "date_of_birth": date(1989, 3, 11), "facility_code": "MDU"},
+        {"first_name": "Nivetha", "last_name": "Sundaram", "place": "Coimbatore", "gender": Gender.FEMALE, "date_of_birth": date(1996, 7, 24), "facility_code": "CBE"},
+        {"first_name": "Pradeep", "last_name": "Subramanian", "place": "Tirunelveli", "gender": Gender.MALE, "date_of_birth": date(1991, 11, 5), "facility_code": "TVL"},
+        {"first_name": "Anitha", "last_name": "Balasubramaniam", "place": "Salem", "gender": Gender.FEMALE, "date_of_birth": date(1994, 1, 17), "facility_code": "SLM"},
+        {"first_name": "Vignesh", "last_name": "Narayanan", "place": "Erode", "gender": Gender.MALE, "date_of_birth": date(1987, 10, 9), "facility_code": "ERD"},
+        {"first_name": "Harini", "last_name": "Sivakumar", "place": "Chengalpattu", "gender": Gender.FEMALE, "date_of_birth": date(1998, 5, 28), "facility_code": "CGP"},
+        {"first_name": "Sathish", "last_name": "Arumugam", "place": "Trichy", "gender": Gender.MALE, "date_of_birth": date(1992, 12, 14), "facility_code": "TRY"},
+        {"first_name": "Meena", "last_name": "Rajendran", "place": "Thanjavur", "gender": Gender.FEMALE, "date_of_birth": date(1993, 4, 3), "facility_code": "TNJ"},
+        {"first_name": "Aravind", "last_name": "Muthukumar", "place": "Vellore", "gender": Gender.MALE, "date_of_birth": date(1990, 8, 19), "facility_code": "VLR"},
+        {"first_name": "Keerthana", "last_name": "Manikandan", "place": "Kanchipuram", "gender": Gender.FEMALE, "date_of_birth": date(1997, 9, 30), "facility_code": "KPM"},
+        {"first_name": "Dinesh", "last_name": "Saravanan", "place": "Tiruppur", "gender": Gender.MALE, "date_of_birth": date(1988, 2, 21), "facility_code": "TPR"},
+        {"first_name": "Yamini", "last_name": "Periyasamy", "place": "Nagapattinam", "gender": Gender.FEMALE, "date_of_birth": date(1995, 6, 12), "facility_code": "NGP"},
     ]
 
     def add_arguments(self, parser):
@@ -79,13 +80,16 @@ class Command(BaseCommand):
                 "uhid": uhid,
                 "first_name": profile["first_name"],
                 "last_name": profile["last_name"],
+                "gender": profile["gender"],
+                "date_of_birth": profile["date_of_birth"],
+                "place": profile["place"],
                 "phone_number": self._build_phone_number(i),
                 "status": CaseStatus.ACTIVE,
                 "created_by": demo_user,
-                "notes": f"Demo follow-up case from {profile['town']} OPD with reachable caretaker contact.",
+                "notes": f"Demo follow-up case from {profile['place']} OPD with reachable caretaker contact.",
             }
 
-            if bucket == 1:
+            if bucket == 1 and profile["gender"] != Gender.MALE:
                 case = Case.objects.create(
                     category=anc,
                     lmp=today - timedelta(days=50 + i),

--- a/patients/tests.py
+++ b/patients/tests.py
@@ -195,3 +195,9 @@ class SeedMockDataCommandTests(TestCase):
         for case in seeded_cases:
             self.assertRegex(case.uhid, r"^TN-[A-Z]{3}-\d{6}$")
             self.assertRegex(case.phone_number, r"^[6-9]\d{9}$")
+            self.assertTrue(case.gender)
+            self.assertIsNotNone(case.date_of_birth)
+            self.assertTrue(case.place)
+
+        anc_cases = seeded_cases.filter(category__name="ANC")
+        self.assertFalse(anc_cases.filter(gender="MALE").exists())


### PR DESCRIPTION
### Motivation
- The existing mock seed data did not populate `gender`, `date_of_birth`, or `place`, which are required by the Case model and test coverage.
- Male patients must not be seeded into the ANC department, so the seeding logic should avoid assigning ANC to male mock profiles.
- The user should be able to update the running database with the new mock set without a full fresh start by re-running the seed command with the provided reset option.

### Description
- Enriched `mock_profiles` in `patients/management/commands/seed_mock_data.py` to include `gender`, `date_of_birth` (as `date` objects), and `place`, and added the `date` import and `Gender` model import.
- Updated the seed payload to persist `gender`, `date_of_birth`, and `place` on created `Case` records and changed demo notes to reference `place` instead of `town`.
- Adjusted ANC routing so ANC bucket creation now runs only when the selected mock profile is not `Gender.MALE`, preventing male mock patients from being created as ANC cases.
- Expanded the seed command tests in `patients/tests.py` to assert that seeded cases include `gender`, `date_of_birth`, and `place`, and to verify that ANC-seeded cases do not include male patients.

### Testing
- Ran `SECRET_KEY=test DATABASE_URL=sqlite:///db.sqlite3 python manage.py test patients.tests.SeedMockDataCommandTests` which passed (test class ran and reported OK).
- Ran `SECRET_KEY=test DATABASE_URL=sqlite:///db.sqlite3 python manage.py test patients.tests` which ran 9 tests and reported OK.
- Attempted the Docker-based test `docker compose exec web python manage.py test patients.tests.SeedMockDataCommandTests` but could not run it in this environment because `docker` is not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f19e4dcb4832787292102b4e86a8a)