### PR TITLE
Refine case detail activity log and task status presentation

### DIFF
--- a/patients/forms.py
+++ b/patients/forms.py
@@ -85,7 +85,7 @@ class TaskForm(StyledModelForm):
 class ActivityLogForm(StyledModelForm):
     class Meta:
         model = CaseActivityLog
-        fields = ["task", "note"]
+        fields = ["note"]
         widgets = {
             "note": forms.Textarea(attrs={"rows": 2, "placeholder": "Add follow-up note"}),
         }

--- a/patients/views.py
+++ b/patients/views.py
@@ -153,10 +153,7 @@ class CaseDetailView(LoginRequiredMixin, DetailView):
         context["today"] = timezone.localdate()
         context["activity_logs"] = case.activity_logs.select_related("user", "task")[:50]
         context["task_form"] = TaskForm()
-        log_form = ActivityLogForm()
-        log_form.fields["task"].queryset = case.tasks.all()
-        log_form.fields["task"].required = False
-        context["log_form"] = log_form
+        context["log_form"] = ActivityLogForm()
         context["can_task_create"] = has_capability(self.request.user, "task_create")
         context["can_task_edit"] = has_capability(self.request.user, "task_edit")
         context["can_note_add"] = has_capability(self.request.user, "note_add")
@@ -237,14 +234,10 @@ class AddCaseNoteView(LoginRequiredMixin, View):
             return HttpResponseForbidden("You do not have permission to add notes.")
         case = get_object_or_404(Case, pk=pk)
         form = ActivityLogForm(request.POST)
-        form.fields["task"].queryset = case.tasks.all()
         if form.is_valid():
             log = form.save(commit=False)
             log.case = case
             log.user = request.user
-            if log.task and log.task.case_id != case.id:
-                messages.error(request, "Selected task does not belong to this case.")
-                return redirect("patients:case_detail", pk=pk)
             log.save()
             messages.success(request, "Note added.")
         else:

--- a/templates/patients/case_detail.html
+++ b/templates/patients/case_detail.html
@@ -1,6 +1,22 @@
 {% extends 'base.html' %}
 {% block title %}Case {{ case.uhid }} | MEDTRACK{% endblock %}
 {% block content %}
+<style>
+  .task-status-pill {
+    display: inline-block;
+    border-radius: 999px;
+    padding: 0.2rem 0.6rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #fff;
+    white-space: nowrap;
+  }
+
+  .task-status-pill.status-completed { background: #198754; }
+  .task-status-pill.status-scheduled { background: #0d6efd; }
+  .task-status-pill.status-awaiting-reports { background: #fd7e14; }
+  .task-status-pill.status-cancelled { background: #6c757d; }
+</style>
 <div class="d-flex flex-column flex-md-row justify-content-between align-items-start gap-2 mb-3">
   <div>
     <h1 class="h4 mb-1">{{ case.full_name }} <small class="text-muted">({{ case.uhid }})</small></h1>
@@ -31,8 +47,10 @@
           {% for task in tasks %}
             <tr {% if case.category.name|upper == 'ANC' and task.due_date > today %}class="table-secondary"{% endif %}>
               <td>{{ task.title }}</td>
-              <td>{{ task.due_date }}</td>
-              <td>{{ task.get_status_display }}</td>
+              <td>{{ task.due_date|date:'d-m-y' }}</td>
+              <td>
+                <span class="task-status-pill status-{{ task.status|slugify }}">{{ task.get_status_display }}</span>
+              </td>
               <td class="d-none d-md-table-cell">{{ task.frequency_label|default:'-' }}</td>
               <td class="d-none d-md-table-cell">{{ task.assigned_user|default:'-' }}</td>
               <td>
@@ -64,7 +82,6 @@
       <h2 class="h5">Activity Log</h2>
       {% if can_note_add %}
       <form method="post" action="{% url 'patients:case_note_create' case.id %}" class="mb-3">{% csrf_token %}
-        <div class="mb-2">{{ log_form.task.label_tag }} {{ log_form.task }}</div>
         <div class="mb-2">{{ log_form.note.label_tag }} {{ log_form.note }}</div>
         <button class="btn btn-secondary btn-sm w-100">Add Note</button>
       </form>


### PR DESCRIPTION
### Motivation
- Make the case activity log behave as a pure history / note entry area by removing the task picker from manual notes so users can quickly append timeline entries.
- Improve visual clarity of tasks on the case detail page by showing due dates in `dd-mm-yy` format and clear, colored status pills for easier scanning.
- Keep system-generated activity entries that reference tasks intact while simplifying the manual note workflow.

### Description
- Removed the `task` field from the manual activity log form by changing `ActivityLogForm` to only include `note` (file: `patients/forms.py`).
- Simplified the note creation flow in `AddCaseNoteView` to save a note-only `CaseActivityLog` (file: `patients/views.py`).
- Updated the case detail template to display task due dates using `{{ task.due_date|date:'d-m-y' }}` and to render status as rounded, colored pills using small inline CSS classes (file: `templates/patients/case_detail.html`).
- Added a regression test to confirm a manual note can be posted without selecting a task and is stored with `task=None` (file: `patients/tests.py`).

### Testing
- Ran migrations with `SECRET_KEY=test DATABASE_URL=sqlite:////tmp/patient_registry_ui.sqlite3 python manage.py migrate` which applied all migrations successfully.
- Seeded demo data with `SECRET_KEY=test DATABASE_URL=sqlite:////tmp/patient_registry_ui.sqlite3 python manage.py seed_mock_data --count 5 --reset` which created mock cases.
- Ran focused tests with `SECRET_KEY=test DATABASE_URL=sqlite:////tmp/patient_registry_test.sqlite3 python manage.py test patients.tests.MedtrackViewTests.test_case_note_add_does_not_require_task_selection patients.tests.MedtrackViewTests.test_create_anc_case_autogenerates_tasks` and the full app tests with `SECRET_KEY=test DATABASE_URL=sqlite:////tmp/patient_registry_test.sqlite3 python manage.py test patients.tests`, both of which passed (`OK`).
- Attempted to capture a UI screenshot using Playwright, but the automated browser run failed to reach the running server in this environment so no screenshot artifact was produced; all server-side checks and tests are green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f1c0df5d083278dd32c52fc06f38a)