### PR TITLE
Group dashboard tasks into patient-day cards and update templates

### DIFF
--- a/templates/patients/case_detail.html
+++ b/templates/patients/case_detail.html
@@ -14,7 +14,9 @@
 
   .task-status-pill.status-completed { background: #198754; }
   .task-status-pill.status-scheduled { background: #0d6efd; }
-  .task-status-pill.status-awaiting-reports { background: #fd7e14; }
+  .task-status-pill.status-awaiting-reports,
+  .task-status-pill.status-awaiting-results,
+  .task-status-pill.status-awating-results { background: #fd7e14; }
   .task-status-pill.status-cancelled { background: #6c757d; }
 </style>
 <div class="d-flex flex-column flex-md-row justify-content-between align-items-start gap-2 mb-3">

--- a/templates/patients/dashboard.html
+++ b/templates/patients/dashboard.html
@@ -14,19 +14,67 @@
 <div class="row g-3 g-md-4">
   <div class="col-12 col-lg-6">
     <h2 class="h6">Today's Tasks</h2>
-    <ul class="list-group mb-3">
-      {% for task in today_tasks %}<li class="list-group-item small"><a href="{% url 'patients:case_detail' task.case_id %}">{{ task.case.uhid }}</a> — {{ task.title }} ({{ task.due_date }})</li>{% empty %}<li class="list-group-item">No tasks due today.</li>{% endfor %}
-    </ul>
-    <h2 class="h6">Upcoming ({{ upcoming_days }} days)</h2>
-    <ul class="list-group">
-      {% for task in upcoming_tasks %}<li class="list-group-item small">{{ task.due_date }} — <a href="{% url 'patients:case_detail' task.case_id %}">{{ task.case.full_name }}</a> / {{ task.title }}</li>{% empty %}<li class="list-group-item">No upcoming tasks.</li>{% endfor %}
-    </ul>
+    {% for card in today_cards %}
+      <div class="card mb-3 shadow-sm">
+        <div class="card-body py-2 px-3">
+          <div class="d-flex align-items-center flex-wrap gap-1 small">
+            <span class="text-muted">{{ card.due_date|date:'M d' }} —</span>
+            <a class="fw-semibold text-decoration-none" href="{% url 'patients:case_detail' card.case_id %}">{{ card.patient_name }}</a>
+            <span class="text-muted">/ {{ card.diagnosis }} /</span>
+            <a class="text-decoration-none" href="tel:{{ card.phone_number }}" data-bs-toggle="collapse" data-bs-target="#today-phone-{{ forloop.counter }}" aria-expanded="false" aria-controls="today-phone-{{ forloop.counter }}" title="Show and call patient">
+              📞
+            </a>
+            <span id="today-phone-{{ forloop.counter }}" class="collapse text-muted">{{ card.phone_number }}</span>
+          </div>
+          <div class="text-muted small mt-1">{{ card.task_titles|join:' • ' }}</div>
+        </div>
+      </div>
+    {% empty %}
+      <div class="card"><div class="card-body">No tasks due today.</div></div>
+    {% endfor %}
+
+    <h2 class="h6 mt-3">Upcoming ({{ upcoming_days }} days)</h2>
+    {% for card in upcoming_cards %}
+      <div class="card mb-3 shadow-sm">
+        <div class="card-body py-2 px-3">
+          <div class="d-flex align-items-center flex-wrap gap-1 small">
+            <span class="text-muted">{{ card.due_date|date:'M d' }} —</span>
+            <a class="fw-semibold text-decoration-none" href="{% url 'patients:case_detail' card.case_id %}">{{ card.patient_name }}</a>
+            <span class="text-muted">/ {{ card.diagnosis }} /</span>
+            <a class="text-decoration-none" href="tel:{{ card.phone_number }}" data-bs-toggle="collapse" data-bs-target="#upcoming-phone-{{ forloop.counter }}" aria-expanded="false" aria-controls="upcoming-phone-{{ forloop.counter }}" title="Show and call patient">
+              📞
+            </a>
+            <span id="upcoming-phone-{{ forloop.counter }}" class="collapse text-muted">{{ card.phone_number }}</span>
+          </div>
+          <div class="text-muted small mt-1">{{ card.task_titles|join:' • ' }}</div>
+        </div>
+      </div>
+    {% empty %}
+      <div class="card"><div class="card-body">No upcoming tasks.</div></div>
+    {% endfor %}
   </div>
+
   <div class="col-12 col-lg-6">
     <h2 class="h6">Overdue Tasks</h2>
-    <ul class="list-group mb-3">
-      {% for task in overdue_tasks %}<li class="list-group-item small">{{ task.due_date }} — <a href="{% url 'patients:case_detail' task.case_id %}">{{ task.case.uhid }}</a> / {{ task.title }}</li>{% empty %}<li class="list-group-item">No overdue tasks.</li>{% endfor %}
-    </ul>
+    {% for card in overdue_cards %}
+      <div class="card mb-3 border-danger-subtle shadow-sm">
+        <div class="card-body py-2 px-3">
+          <div class="d-flex align-items-center flex-wrap gap-1 small">
+            <span class="text-danger">{{ card.due_date|date:'M d' }} —</span>
+            <a class="fw-semibold text-decoration-none" href="{% url 'patients:case_detail' card.case_id %}">{{ card.patient_name }}</a>
+            <span class="text-muted">/ {{ card.diagnosis }} /</span>
+            <a class="text-decoration-none" href="tel:{{ card.phone_number }}" data-bs-toggle="collapse" data-bs-target="#overdue-phone-{{ forloop.counter }}" aria-expanded="false" aria-controls="overdue-phone-{{ forloop.counter }}" title="Show and call patient">
+              📞
+            </a>
+            <span id="overdue-phone-{{ forloop.counter }}" class="collapse text-muted">{{ card.phone_number }}</span>
+          </div>
+          <div class="text-muted small mt-1">{{ card.task_titles|join:' • ' }}</div>
+        </div>
+      </div>
+    {% empty %}
+      <div class="card"><div class="card-body">No overdue tasks.</div></div>
+    {% endfor %}
+
     <h2 class="h6">Awaiting Reports</h2>
     <ul class="list-group">
       {% for task in awaiting_tasks %}<li class="list-group-item small"><a href="{% url 'patients:case_detail' task.case_id %}">{{ task.case.full_name }}</a> — {{ task.title }}</li>{% empty %}<li class="list-group-item">No awaiting-report tasks.</li>{% endfor %}


### PR DESCRIPTION
### Motivation

- Provide a clearer dashboard view by grouping multiple tasks for the same patient and day into a single «card» so users can see patient-level items at-a-glance.
- Improve performance and data completeness by eager-loading related objects and enforcing a predictable ordering for tasks.

### Description

- Added `_build_patient_day_cards` to `DashboardView` to aggregate tasks by `(due_date, case_id)` and produce cards with `patient_name`, `diagnosis`, `phone_number`, and deduplicated `task_titles`.
- Expanded `select_related` in `DashboardView.get_queryset` and other task queries to include `case__category` and added ordering by `due_date`, `case_id`, `id` for deterministic grouping.
- Populated `today_cards`, `upcoming_cards`, and `overdue_cards` in the context via `_build_patient_day_cards` while retaining the original task querysets (`today_tasks`, `upcoming_tasks`, `overdue_tasks`, `awaiting_tasks`).
- Reworked `templates/patients/dashboard.html` to render the new card UI with patient link, diagnosis, collapsible phone number and joined task titles for today/upcoming/overdue sections.
- Minor template correction in `templates/patients/case_detail.html` to map additional status class names to the awaiting color (added `status-awaiting-results` and `status-awating-results`).
- Added `test_dashboard_groups_tasks_by_patient_and_day` to `patients/tests.py` to validate grouping behavior and card contents.

### Testing

- Ran the patients test suite with `./manage.py test patients` including `patients.tests.MedtrackViewTests.test_dashboard_groups_tasks_by_patient_and_day`, and the tests passed.
- Existing dashboard-related tests (task creation, case creation, task generation) were executed and passed as part of the same test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f1f7c879c8327a0682b5f552fe11e)