### PR TITLE
Fix missing badge background for 'Awaiting Reports' tasks

### DIFF
--- a/templates/patients/case_detail.html
+++ b/templates/patients/case_detail.html
@@ -14,6 +14,7 @@
 
   .task-status-pill.status-completed { background: #198754; }
   .task-status-pill.status-scheduled { background: #0d6efd; }
+  .task-status-pill.status-awaiting_reports,
   .task-status-pill.status-awaiting-reports,
   .task-status-pill.status-awaiting-results,
   .task-status-pill.status-awating-results { background: #fd7e14; }


### PR DESCRIPTION
### Motivation
- Task status badges for `AWAITING_REPORTS` were rendered without a background color because the CSS did not include the class name produced by `slugify` (`status-awaiting_reports`).
- Keep visual status indicators consistent so Awaiting Reports tasks show the same orange pill as other awaiting/result statuses.

### Description
- Added the `.task-status-pill.status-awaiting_reports` selector to `templates/patients/case_detail.html` so the `AWAITING_REPORTS` status receives the orange background (`#fd7e14`).
- Change is scoped to the task badge CSS in the case detail template and does not alter any backend logic or models.

### Testing
- Captured a UI screenshot after deploying the change to verify the badge appearance in the browser (artifact saved).
- Ran `docker compose exec web python manage.py test` but the environment does not have the `docker` CLI available, so this command could not be executed here.
- Ran `python manage.py test` locally in the workspace but it failed due to missing environment variables (`SECRET_KEY`), so automated test suite could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f23e29db48327ba9b1a20903ad7bd)