### PR TITLE
Expand mock seed data coverage to 30 cases with new fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@ Open:
 - `http://localhost:8000/patients/`
 - `http://localhost:8000/patients/settings/` (admin role/settings page)
 
-## Demo data (10 mock cases)
+## Demo data (30 mock cases)
 
 To quickly see the app with sample records:
 
 ```bash
-docker compose exec web python manage.py seed_mock_data --count 10 --reset
+docker compose exec web python manage.py seed_mock_data --count 30 --reset
 ```
 
-- `--count` controls how many mock cases to create (default: `10`).
+- `--count` controls how many mock cases to create (default: `30`).
 - `--reset` clears existing case/task/activity data before seeding.
 
 ## Updating to latest version safely (with backup)


### PR DESCRIPTION
### Motivation
- Provide a richer, more representative demo dataset (30 cases) so QA and manual testing exercise the newly added Case fields and edge scenarios introduced today. 
- Ensure seeded data exercises all major workflows: ANC obstetrics, planned and surveillance surgery, non-surgical review rhythms, and mixed case statuses for dashboard/testing coverage.

### Description
- Changed `seed_mock_data` default `--count` from `10` to `30` and widened the bucket logic to generate more varied scenarios. (`patients/management/commands/seed_mock_data.py`)
- Populated additional Case fields when seeding: `age`, `alternate_phone_number`, varied `status`, `diagnosis`, `ncd_flags`, `referred_by`, and `high_risk`, and added `usg_edd`, `gravida`, `para`, `abortions`, `living` for ANC cases. (`seed_mock_data`)
- Introduced mixed surgery scenarios including both `PLANNED_SURGERY` and `SURVEILLANCE`, `surgery_done` flags and conditional `surgery_date`/`review_date`, and diversified `review_frequency` for non-surgical cases. (`seed_mock_data`)
- Updated the unit test to call the seed command for 30 cases and assert presence/format of new fields and coverage across ANC/Surgery/Non Surgical pathways. (`patients/tests.py`)
- Updated README demo-data section to document the 30-case default and example command. (`README.md`)

### Testing
- Ran `python manage.py test patients.tests.SeedMockDataCommandTests` without env and it failed due to missing `SECRET_KEY` environment variable (expected in normal settings). 
- Ran the seed test with explicit env vars and SQLite and it passed: `SECRET_KEY=test DATABASE_URL=sqlite:///db.sqlite3 python manage.py test patients.tests.SeedMockDataCommandTests` (OK).
- Attempted to run the Docker-based test `docker compose exec web python manage.py test patients.tests.SeedMockDataCommandTests` but the `docker` CLI was unavailable in this execution environment (failed to run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f28789c9883279e4c961bbe320089)