### PR TITLE
Improve new case form layout, DOB→age behavior, and risk-factor multi-select UI

### DIFF
--- a/patients/forms.py
+++ b/patients/forms.py
@@ -22,7 +22,7 @@ class StyledModelForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         for field in self.fields.values():
-            if isinstance(field.widget, forms.CheckboxInput):
+            if isinstance(field.widget, (forms.CheckboxInput, forms.CheckboxSelectMultiple)):
                 css_class = "form-check-input"
             elif isinstance(field.widget, forms.Select):
                 css_class = "form-select"
@@ -53,6 +53,16 @@ class CaseForm(StyledModelForm):
 
     def clean(self):
         cleaned_data = super().clean()
+        dob = cleaned_data.get("date_of_birth")
+        entered_age = cleaned_data.get("age")
+        if dob:
+            today = timezone.localdate()
+            years = today.year - dob.year
+            has_had_birthday = (today.month, today.day) >= (dob.month, dob.day)
+            cleaned_data["age"] = years if has_had_birthday else years - 1
+        elif entered_age is None:
+            self.add_error("age", "Enter age when date of birth is not available.")
+
         category = cleaned_data.get("category")
         category_name = category.name.upper() if category else ""
 

--- a/templates/patients/case_form.html
+++ b/templates/patients/case_form.html
@@ -1,46 +1,131 @@
 {% extends 'base.html' %}
 {% block title %}Case Form | MEDTRACK{% endblock %}
 {% block content %}
-<div class="card"><div class="card-body">
-  <h1 class="h4">{% if object %}Edit Case{% else %}New Case{% endif %}</h1>
+<style>
+  .case-section-card {
+    border: 1px solid #d9dee8;
+    border-radius: 0.75rem;
+    background: #fff;
+  }
+  .case-section-card .card-header {
+    border-bottom: 1px solid #e8ecf4;
+    background: #f3f7ff;
+    border-radius: 0.75rem 0.75rem 0 0;
+  }
+  .ncd-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 0.5rem 1rem;
+  }
+  .ncd-grid .form-check {
+    margin: 0;
+  }
+  .ncd-grid .form-check-label {
+    margin-left: 0.35rem;
+  }
+</style>
+
+<div class="card shadow-sm"><div class="card-body">
+  <h1 class="h4 mb-1">{% if object %}Edit Case{% else %}New Case{% endif %}</h1>
   <p class="text-muted small mb-3">Step 1: choose category · Step 2: complete relevant sections only.</p>
+
   <form method="post" class="row g-3" id="case-form">{% csrf_token %}
-    <div class="col-12 col-md-6 field-wrap" data-field="category"><label class="form-label">{{ form.category.label }}</label>{{ form.category }}</div>
+    <div class="col-12">
+      <div class="case-section-card">
+        <div class="card-header px-3 py-2">
+          <h2 class="h6 mb-0">Case Type</h2>
+        </div>
+        <div class="card-body row g-3">
+          <div class="col-12 col-md-6 field-wrap" data-field="category">
+            <label class="form-label">{{ form.category.label }}</label>
+            {{ form.category }}
+          </div>
+          <div class="col-12 col-md-6 field-wrap" data-field="status">
+            <label class="form-label">{{ form.status.label }}</label>
+            {{ form.status }}
+          </div>
+        </div>
+      </div>
+    </div>
 
-    <div class="col-12"><h2 class="h6 mb-1">Patient Info</h2></div>
-    <div class="col-md-6 field-wrap" data-field="uhid"><label class="form-label">{{ form.uhid.label }}</label>{{ form.uhid }}</div>
-    <div class="col-md-6 field-wrap" data-field="first_name"><label class="form-label">{{ form.first_name.label }}</label>{{ form.first_name }}</div>
-    <div class="col-md-6 field-wrap" data-field="last_name"><label class="form-label">{{ form.last_name.label }}</label>{{ form.last_name }}</div>
-    <div class="col-md-6 field-wrap" data-field="gender"><label class="form-label">{{ form.gender.label }}</label>{{ form.gender }}</div>
-    <div class="col-md-6 field-wrap" data-field="date_of_birth"><label class="form-label">{{ form.date_of_birth.label }}</label>{{ form.date_of_birth }}</div>
-    <div class="col-md-6 field-wrap" data-field="age"><label class="form-label">{{ form.age.label }}</label>{{ form.age }}</div>
-    <div class="col-md-6 field-wrap" data-field="place"><label class="form-label">{{ form.place.label }}</label>{{ form.place }}</div>
-    <div class="col-md-6 field-wrap" data-field="phone_number"><label class="form-label">{{ form.phone_number.label }}</label>{{ form.phone_number }}</div>
-    <div class="col-md-6 field-wrap" data-field="alternate_phone_number"><label class="form-label">{{ form.alternate_phone_number.label }}</label>{{ form.alternate_phone_number }}</div>
-    <div class="col-md-6 field-wrap" data-field="status"><label class="form-label">{{ form.status.label }}</label>{{ form.status }}</div>
+    <div class="col-12">
+      <div class="case-section-card">
+        <div class="card-header px-3 py-2">
+          <h2 class="h6 mb-0">Personal Details</h2>
+        </div>
+        <div class="card-body row g-3">
+          <div class="col-md-6 field-wrap" data-field="uhid"><label class="form-label">{{ form.uhid.label }}</label>{{ form.uhid }}</div>
+          <div class="col-md-6 field-wrap" data-field="first_name"><label class="form-label">{{ form.first_name.label }}</label>{{ form.first_name }}</div>
+          <div class="col-md-6 field-wrap" data-field="last_name"><label class="form-label">{{ form.last_name.label }}</label>{{ form.last_name }}</div>
+          <div class="col-md-6 field-wrap" data-field="gender"><label class="form-label">{{ form.gender.label }}</label>{{ form.gender }}</div>
+          <div class="col-md-6 field-wrap" data-field="date_of_birth">
+            <label class="form-label">{{ form.date_of_birth.label }}</label>
+            {{ form.date_of_birth }}
+            <div class="form-text">When DOB is entered, age is auto-calculated.</div>
+          </div>
+          <div class="col-md-6 field-wrap" data-field="age">
+            <label class="form-label">{{ form.age.label }}</label>
+            {{ form.age }}
+            <div class="form-text" id="age-help-text">Enter age manually only if DOB is unknown.</div>
+          </div>
+          <div class="col-md-6 field-wrap" data-field="place"><label class="form-label">{{ form.place.label }}</label>{{ form.place }}</div>
+          <div class="col-md-6 field-wrap" data-field="phone_number"><label class="form-label">{{ form.phone_number.label }}</label>{{ form.phone_number }}</div>
+          <div class="col-md-6 field-wrap" data-field="alternate_phone_number"><label class="form-label">{{ form.alternate_phone_number.label }}</label>{{ form.alternate_phone_number }}</div>
+        </div>
+      </div>
+    </div>
 
-    <div class="col-12"><h2 class="h6 mb-1">Clinical Info</h2></div>
-    <div class="col-md-6 field-wrap" data-field="diagnosis"><label class="form-label">{{ form.diagnosis.label }}</label>{{ form.diagnosis }}</div>
-    <div class="col-md-6 field-wrap" data-field="lmp"><label class="form-label">{{ form.lmp.label }}</label>{{ form.lmp }}</div>
-    <div class="col-md-6 field-wrap" data-field="edd"><label class="form-label">{{ form.edd.label }}</label>{{ form.edd }}</div>
-    <div class="col-md-6 field-wrap" data-field="usg_edd"><label class="form-label">{{ form.usg_edd.label }}</label>{{ form.usg_edd }}</div>
-    <div class="col-md-6 field-wrap" data-field="surgical_pathway"><label class="form-label">{{ form.surgical_pathway.label }}</label>{{ form.surgical_pathway }}</div>
-    <div class="col-md-6 field-wrap" data-field="surgery_done"><label class="form-label">{{ form.surgery_done.label }}</label>{{ form.surgery_done }}</div>
-    <div class="col-md-6 field-wrap" data-field="surgery_date"><label class="form-label">{{ form.surgery_date.label }}</label>{{ form.surgery_date }}</div>
-    <div class="col-md-6 field-wrap" data-field="review_frequency"><label class="form-label">{{ form.review_frequency.label }}</label>{{ form.review_frequency }}</div>
-    <div class="col-md-6 field-wrap" data-field="review_date"><label class="form-label">{{ form.review_date.label }}</label>{{ form.review_date }}</div>
-    <div class="col-md-3 field-wrap" data-field="gravida"><label class="form-label">G</label>{{ form.gravida }}</div>
-    <div class="col-md-3 field-wrap" data-field="para"><label class="form-label">P</label>{{ form.para }}</div>
-    <div class="col-md-3 field-wrap" data-field="abortions"><label class="form-label">A</label>{{ form.abortions }}</div>
-    <div class="col-md-3 field-wrap" data-field="living"><label class="form-label">L</label>{{ form.living }}<div id="gpla-warning" class="small text-warning d-none">L is greater than P (allowed for multiple births).</div></div>
+    <div class="col-12">
+      <div class="case-section-card">
+        <div class="card-header px-3 py-2">
+          <h2 class="h6 mb-0">Diagnosis & Follow-up Details</h2>
+        </div>
+        <div class="card-body row g-3">
+          <div class="col-md-6 field-wrap" data-field="diagnosis"><label class="form-label">{{ form.diagnosis.label }}</label>{{ form.diagnosis }}</div>
+          <div class="col-md-6 field-wrap" data-field="lmp"><label class="form-label">{{ form.lmp.label }}</label>{{ form.lmp }}</div>
+          <div class="col-md-6 field-wrap" data-field="edd"><label class="form-label">{{ form.edd.label }}</label>{{ form.edd }}</div>
+          <div class="col-md-6 field-wrap" data-field="usg_edd"><label class="form-label">{{ form.usg_edd.label }}</label>{{ form.usg_edd }}</div>
+          <div class="col-md-6 field-wrap" data-field="surgical_pathway"><label class="form-label">{{ form.surgical_pathway.label }}</label>{{ form.surgical_pathway }}</div>
+          <div class="col-md-6 field-wrap" data-field="surgery_done"><label class="form-label">{{ form.surgery_done.label }}</label>{{ form.surgery_done }}</div>
+          <div class="col-md-6 field-wrap" data-field="surgery_date"><label class="form-label">{{ form.surgery_date.label }}</label>{{ form.surgery_date }}</div>
+          <div class="col-md-6 field-wrap" data-field="review_frequency"><label class="form-label">{{ form.review_frequency.label }}</label>{{ form.review_frequency }}</div>
+          <div class="col-md-6 field-wrap" data-field="review_date"><label class="form-label">{{ form.review_date.label }}</label>{{ form.review_date }}</div>
+          <div class="col-md-3 field-wrap" data-field="gravida"><label class="form-label">G</label>{{ form.gravida }}</div>
+          <div class="col-md-3 field-wrap" data-field="para"><label class="form-label">P</label>{{ form.para }}</div>
+          <div class="col-md-3 field-wrap" data-field="abortions"><label class="form-label">A</label>{{ form.abortions }}</div>
+          <div class="col-md-3 field-wrap" data-field="living"><label class="form-label">L</label>{{ form.living }}<div id="gpla-warning" class="small text-warning d-none">L is greater than P (allowed for multiple births).</div></div>
+        </div>
+      </div>
+    </div>
 
-    <div class="col-12"><h2 class="h6 mb-1">Risk Factors</h2></div>
-    <div class="col-md-6 field-wrap" data-field="high_risk"><label class="form-label">{{ form.high_risk.label }}</label>{{ form.high_risk }}</div>
-    <div class="col-md-6 field-wrap" data-field="ncd_flags"><label class="form-label">{{ form.ncd_flags.label }}</label>{{ form.ncd_flags }}</div>
+    <div class="col-12">
+      <div class="case-section-card">
+        <div class="card-header px-3 py-2">
+          <h2 class="h6 mb-0">Risk Factors</h2>
+        </div>
+        <div class="card-body row g-3">
+          <div class="col-md-6 field-wrap" data-field="high_risk"><label class="form-label">{{ form.high_risk.label }}</label>{{ form.high_risk }}</div>
+          <div class="col-md-6 field-wrap" data-field="ncd_flags">
+            <label class="form-label">{{ form.ncd_flags.label }}</label>
+            <div class="ncd-grid border rounded p-2 bg-light-subtle">
+              {{ form.ncd_flags }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
 
-    <div class="col-12"><h2 class="h6 mb-1">Referral Info</h2></div>
-    <div class="col-md-6 field-wrap" data-field="referred_by"><label class="form-label">{{ form.referred_by.label }}</label>{{ form.referred_by }}</div>
-    <div class="col-md-6 field-wrap" data-field="notes"><label class="form-label">{{ form.notes.label }}</label>{{ form.notes }}</div>
+    <div class="col-12">
+      <div class="case-section-card">
+        <div class="card-header px-3 py-2">
+          <h2 class="h6 mb-0">Referral Notes</h2>
+        </div>
+        <div class="card-body row g-3">
+          <div class="col-md-6 field-wrap" data-field="referred_by"><label class="form-label">{{ form.referred_by.label }}</label>{{ form.referred_by }}</div>
+          <div class="col-md-6 field-wrap" data-field="notes"><label class="form-label">{{ form.notes.label }}</label>{{ form.notes }}</div>
+        </div>
+      </div>
+    </div>
 
     {% for field in form %}
       {% for error in field.errors %}<div class="col-12 text-danger small">{{ field.label }}: {{ error }}</div>{% endfor %}
@@ -54,6 +139,11 @@
 (function() {
   const categoryEl = document.getElementById('id_category');
   if (!categoryEl) return;
+
+  const dobEl = document.getElementById('id_date_of_birth');
+  const ageEl = document.getElementById('id_age');
+  const ageHelpText = document.getElementById('age-help-text');
+
   const fieldsForCategory = {
     anc: ['lmp', 'edd', 'usg_edd', 'gravida', 'para', 'abortions', 'living', 'high_risk'],
     surgery: ['surgical_pathway', 'surgery_done', 'surgery_date', 'review_date'],
@@ -61,6 +151,33 @@
   };
   const allConditional = ['lmp', 'edd', 'usg_edd', 'surgical_pathway', 'surgery_done', 'surgery_date', 'review_frequency', 'review_date', 'gravida', 'para', 'abortions', 'living', 'high_risk'];
   const normalize = (txt) => (txt || '').toLowerCase().replace(/[^a-z]/g, '');
+
+  function calculateAgeFromDob(dobValue) {
+    if (!dobValue) return '';
+    const dob = new Date(dobValue);
+    if (Number.isNaN(dob.getTime())) return '';
+
+    const today = new Date();
+    let years = today.getFullYear() - dob.getFullYear();
+    const monthDiff = today.getMonth() - dob.getMonth();
+    const dayDiff = today.getDate() - dob.getDate();
+    if (monthDiff < 0 || (monthDiff === 0 && dayDiff < 0)) {
+      years -= 1;
+    }
+    return years >= 0 ? years : '';
+  }
+
+  function updateAgeBehavior() {
+    if (!dobEl || !ageEl) return;
+    if (dobEl.value) {
+      ageEl.value = calculateAgeFromDob(dobEl.value);
+      ageEl.setAttribute('readonly', 'readonly');
+      ageHelpText.textContent = 'Age is auto-calculated from DOB.';
+    } else {
+      ageEl.removeAttribute('readonly');
+      ageHelpText.textContent = 'Enter age manually only if DOB is unknown.';
+    }
+  }
 
   function updateFieldVisibility() {
     const normalized = normalize(categoryEl.options[categoryEl.selectedIndex]?.text);
@@ -79,10 +196,13 @@
   }
 
   categoryEl.addEventListener('change', updateFieldVisibility);
+  dobEl?.addEventListener('change', updateAgeBehavior);
   document.getElementById('id_para')?.addEventListener('change', updateGPLAWarning);
   document.getElementById('id_living')?.addEventListener('change', updateGPLAWarning);
+
   updateFieldVisibility();
   updateGPLAWarning();
+  updateAgeBehavior();
 })();
 </script>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Improve usability and visual clarity of the New Case page by grouping related fields and making the form easier to scan. 
- Automatically derive age from date of birth where available to reduce manual errors while still supporting manual age entry when DOB is unavailable. 
- Fix the Risk Factors display so multi-select NCD flags render and style correctly.

### Description
- Reworked `templates/patients/case_form.html` to group fields into card-style sections (Case Type, Personal Details, Diagnosis & Follow-up, Risk Factors, Referral Notes) and added lightweight CSS for improved spacing and visual separation. 
- Added front-end DOB→age logic in the case form template that auto-calculates age from `date_of_birth`, sets the `age` field to readonly when DOB is present, and leaves it editable when DOB is missing. 
- Added server-side handling in `CaseForm.clean()` (`patients/forms.py`) to derive `age` from `date_of_birth` and to require `age` when DOB is not provided, ensuring behavior works without JavaScript. 
- Fixed checkbox styling by treating `CheckboxSelectMultiple` as checkbox inputs in `StyledModelForm`, and wrapped NCD checkboxes in a responsive grid for clearer multi-select presentation. 
- Added tests and small adjustments in `patients/tests.py` to cover DOB-based age calculation and the required manual-age fallback, and updated case-create tests to include `age` where DOB was not posted.

### Testing
- Ran targeted form tests with `SECRET_KEY=test-key DATABASE_URL=sqlite:///db.sqlite3 python manage.py test patients.tests.MedtrackViewTests.test_case_form_uses_dob_to_calculate_age patients.tests.MedtrackViewTests.test_case_form_requires_age_when_dob_missing` which passed. 
- Ran the full app tests with `SECRET_KEY=test-key DATABASE_URL=sqlite:///db.sqlite3 python manage.py test patients.tests` which completed successfully (`15 tests`, all OK). 
- Attempt to run `docker`-based test invocation failed in this environment because `docker` was not available (`bash: command not found: docker`). 
- Attempted automated browser screenshot via Playwright to capture the new UI but the browser-driven attempt timed out / returned `Not Found` in this environment, so no reliable screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f2af60eac8327811338bb36ec1050)