### PR TITLE
Set Inter as the global app font

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -4,12 +4,24 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{% block title %}MEDTRACK{% endblock %}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
       rel="stylesheet"
       integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
       crossorigin="anonymous"
     />
+    <style>
+      body {
+        font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial,
+          sans-serif;
+      }
+    </style>
   </head>
   <body class="bg-light">
     <nav class="navbar navbar-expand-md navbar-dark bg-primary mb-3">


### PR DESCRIPTION
### Motivation
- Standardize the application typography to use `Inter` across all pages that extend `base.html` for a cleaner, more consistent UI.

### Description
- Add Google Fonts `preconnect` hints and the `Inter` stylesheet link and insert a global `body { font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; }` rule in `templates/base.html` so the font is applied site-wide.

### Testing
- Ran `SECRET_KEY=dev DATABASE_URL=sqlite:///tmp.db python manage.py check` which passed with no system check issues.
- Ran `SECRET_KEY=dev DATABASE_URL=sqlite:///tmp.db python manage.py test` which executed 15 tests and all passed (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f32a239108327832a64377f709123)