### PR TITLE
Constrain case autocomplete endpoint and debounce form requests

### DIFF
--- a/templates/patients/case_form.html
+++ b/templates/patients/case_form.html
@@ -251,7 +251,7 @@
 
     function selectSuggestion(index) {
       if (index < 0 || index >= suggestions.length) return;
-      inputEl.value = suggestions[index].text;
+      inputEl.value = suggestions[index];
       closePanel();
     }
 
@@ -287,7 +287,7 @@
         itemEl.className = 'list-group-item list-group-item-action py-1 px-2 small';
         itemEl.id = `${panelId}-item-${index}`;
         itemEl.setAttribute('role', 'option');
-        itemEl.textContent = item.text;
+        itemEl.textContent = item;
         itemEl.addEventListener('mouseenter', () => setActiveSuggestion(index));
         itemEl.addEventListener('mousedown', (event) => {
           event.preventDefault();
@@ -318,13 +318,18 @@
       }
     }
 
+    let debounceHandle = null;
+
     inputEl.addEventListener('input', () => {
       const query = inputEl.value.trim();
-      if (query.length < 1) {
+      if (debounceHandle) {
+        window.clearTimeout(debounceHandle);
+      }
+      if (query.length < 2) {
         closePanel();
         return;
       }
-      fetchSuggestions(query);
+      debounceHandle = window.setTimeout(() => fetchSuggestions(query), 200);
     });
 
     inputEl.addEventListener('keydown', (event) => {


### PR DESCRIPTION
### Motivation
- Limit autocomplete query surface and avoid heavy scans by enforcing a short minimum query length and a hard result cap. 
- Use indexed prefix filtering to keep DB queries fast and predictable. 
- Return a compact, non-PHI response schema and reduce client request volume with a small debounce. 

### Description
- Constrained `CaseAutocompleteView` in `patients/views.py` to require a 2-character minimum query, cap results to 8, and perform an indexed-friendly `istartswith` on the first query token before normalization checks. 
- Switched the endpoint payload to a compact list of suggestion strings (no counts or PHI fields) and preserved short all-caps codes (e.g., `PHC`) while title-casing other values for display. 
- Updated the case form autocomplete script in `templates/patients/case_form.html` to consume the new string-array response and added a 200ms client-side debounce plus client-side minimum-length check. 
- Updated tests in `patients/tests.py` to reflect the new behavior and added coverage for minimum query length and hard result capping. 

### Testing
- Compiled changed files with `python -m compileall patients/views.py templates/patients/case_form.html patients/tests.py` which succeeded. 
- Ran unit tests with environment overrides using `SECRET_KEY=test DATABASE_URL=sqlite:///test.sqlite3 python manage.py test patients.tests.MedtrackViewTests` and the test suite passed (`17 tests`, `OK`). 
- Attempted `docker compose exec web python manage.py test patients.tests.MedtrackViewTests` but the `docker` command was not available in this environment so that run was skipped. }

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f400dc6088327b3962a449827e7fd)