### PR TITLE
Dashboard: add ANC/Surgery/Non Surgical counts, awaiting reports, UI tweaks and tests

### DIFF
--- a/templates/patients/dashboard.html
+++ b/templates/patients/dashboard.html
@@ -3,12 +3,12 @@
 {% block content %}
 <h1 class="h4 mb-3">Dashboard</h1>
 <div class="row g-2 g-md-3 mb-4">
-  <div class="col-6 col-md-2"><div class="card"><div class="card-body py-2 py-md-3"><small>Today's</small><div class="h5 mb-0">{{ today_tasks|length }}</div></div></div></div>
-  <div class="col-6 col-md-2"><div class="card"><div class="card-body py-2 py-md-3"><small>Upcoming</small><div class="h5 mb-0">{{ upcoming_tasks|length }}</div></div></div></div>
-  <div class="col-6 col-md-2"><div class="card"><div class="card-body py-2 py-md-3"><small>Overdue</small><div class="h5 mb-0 text-danger">{{ overdue_tasks|length }}</div></div></div></div>
-  <div class="col-6 col-md-2"><div class="card"><div class="card-body py-2 py-md-3"><small>Awaiting</small><div class="h5 mb-0">{{ awaiting_tasks|length }}</div></div></div></div>
-  <div class="col-6 col-md-2"><div class="card"><div class="card-body py-2 py-md-3"><small>Red List</small><div class="h5 mb-0 text-danger">{{ red_list_count }}</div></div></div></div>
-  <div class="col-6 col-md-2"><div class="card"><div class="card-body py-2 py-md-3"><small>Grey List</small><div class="h5 mb-0 text-secondary">{{ grey_list_count }}</div></div></div></div>
+  <div class="col-6 col-md-2"><div class="card border-primary-subtle"><div class="card-body py-2 py-md-3 bg-primary-subtle"><small>Today's</small><div class="h5 mb-0">{{ today_tasks|length }}</div></div></div></div>
+  <div class="col-6 col-md-2"><div class="card border-info-subtle"><div class="card-body py-2 py-md-3 bg-info-subtle"><small>Upcoming</small><div class="h5 mb-0">{{ upcoming_tasks|length }}</div></div></div></div>
+  <div class="col-6 col-md-2"><div class="card border-danger-subtle"><div class="card-body py-2 py-md-3 bg-danger-subtle"><small>Overdue</small><div class="h5 mb-0 text-danger">{{ overdue_tasks|length }}</div></div></div></div>
+  <div class="col-6 col-md-2"><div class="card border-success-subtle"><div class="card-body py-2 py-md-3 bg-success-subtle"><small>ANC</small><div class="h5 mb-0">{{ anc_case_count }}</div></div></div></div>
+  <div class="col-6 col-md-2"><div class="card border-warning-subtle"><div class="card-body py-2 py-md-3 bg-warning-subtle"><small>Surgery</small><div class="h5 mb-0">{{ surgery_case_count }}</div></div></div></div>
+  <div class="col-6 col-md-2"><div class="card border-secondary-subtle"><div class="card-body py-2 py-md-3 bg-secondary-subtle"><small>Non Surgical</small><div class="h5 mb-0">{{ non_surgical_case_count }}</div></div></div></div>
 </div>
 
 <div class="row g-3 g-md-4">


### PR DESCRIPTION
### Motivation
- Surface per-category active case counts and surface tasks awaiting reports on the dashboard for better situational awareness.
- Group today's tasks by patient and day while showing category-specific metrics in the header.
- Improve dashboard card visual styling to make metrics more distinguishable.

### Description
- Update `DashboardView.get_context_data` to compute `category_counts` from `Case` and expose `anc_case_count`, `surgery_case_count`, and `non_surgical_case_count` in the context and remove legacy red/grey list counts.
- Ensure `awaiting_tasks` is included by filtering `Task` with `TaskStatus.AWAITING_REPORTS` so awaiting-report tasks are available to the template.
- Modify `templates/patients/dashboard.html` to add new header cards for `ANC`, `Surgery`, and `Non Surgical` counts and apply subtle contextual border/background styles to the cards, and to replace the removed red/grey list cards.
- Update `patients/tests.py` to reflect behavior changes: extend `test_dashboard_groups_tasks_by_patient_and_day` to create ANC and non-surgical cases and assert updated `today_cards` grouping and category counts, and add `test_dashboard_shows_awaiting_reports_list` to assert that awaiting-report tasks are visible on the dashboard.

### Testing
- Ran the app test suite for the patients app with `python manage.py test patients` and the updated tests (`test_dashboard_groups_tasks_by_patient_and_day` and `test_dashboard_shows_awaiting_reports_list`) passed.
- Existing dashboard-related tests including `test_dashboard_card_contains_referral_high_risk_and_ncd_flags` were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f5047bac08327ba68c792006bed28)