### PR TITLE
Dashboard: count only active cases in category summaries and update tests

### DIFF
--- a/patients/tests.py
+++ b/patients/tests.py
@@ -288,6 +288,38 @@ class MedtrackViewTests(TestCase):
             review_date=timezone.localdate() + timedelta(days=15),
             created_by=self.user,
         )
+        Case.objects.create(
+            uhid="UH779",
+            first_name="ANC",
+            last_name="Completed",
+            phone_number="9876501113",
+            category=self.anc,
+            status=CaseStatus.COMPLETED,
+            lmp=timezone.localdate() - timedelta(days=60),
+            edd=timezone.localdate() + timedelta(days=210),
+            created_by=self.user,
+        )
+        Case.objects.create(
+            uhid="UH780",
+            first_name="Surgery",
+            last_name="Completed",
+            phone_number="9876501114",
+            category=self.surgery,
+            status=CaseStatus.COMPLETED,
+            surgical_pathway=SurgicalPathway.SURVEILLANCE,
+            review_date=timezone.localdate() + timedelta(days=20),
+            created_by=self.user,
+        )
+        Case.objects.create(
+            uhid="UH781",
+            first_name="Non",
+            last_name="Completed",
+            phone_number="9876501115",
+            category=non_surgical,
+            status=CaseStatus.COMPLETED,
+            review_date=timezone.localdate() + timedelta(days=25),
+            created_by=self.user,
+        )
         Task.objects.create(case=anc_case, title="ANC Review", due_date=timezone.localdate(), created_by=self.user)
         Task.objects.create(case=case, title="Lab", due_date=timezone.localdate(), created_by=self.user)
         Task.objects.create(case=case, title="ECG", due_date=timezone.localdate(), created_by=self.user)

--- a/patients/views.py
+++ b/patients/views.py
@@ -96,7 +96,7 @@ class DashboardView(LoginRequiredMixin, ListView):
         tasks = Task.objects.select_related("case", "case__category", "assigned_user")
         category_counts = {
             (item["category__name"] or "").strip().upper(): item["total"]
-            for item in Case.objects.values("category__name").annotate(total=Count("id"))
+            for item in Case.objects.filter(status=CaseStatus.ACTIVE).values("category__name").annotate(total=Count("id"))
         }
         context["upcoming_tasks"] = tasks.filter(due_date__gt=today, due_date__lte=today + timedelta(days=upcoming_days), status=TaskStatus.SCHEDULED).order_by("due_date", "case_id", "id")
         context["overdue_tasks"] = tasks.exclude(status=TaskStatus.COMPLETED).filter(due_date__lt=today).order_by("due_date", "case_id", "id")


### PR DESCRIPTION
### Motivation

- The dashboard category summary should reflect only active cases, not completed ones, to provide accurate current workload metrics.
- Tests were updated to ensure completed cases are present but excluded from the active category counts.

### Description

- Updated the category aggregation to only include active cases by changing `Case.objects.values(...).annotate(...)` to `Case.objects.filter(status=CaseStatus.ACTIVE).values(...).annotate(...)` in `DashboardView.get_context_data`.
- Ensured context provides counts for active and completed cases via `active_case_count` and `completed_case_count` entries.
- Extended `patients` tests to create additional completed `Case` records (`UH779`–`UH781`) to verify completed cases are not included in the active category summaries.

### Testing

- Ran the dashboard-related test case `patients.tests.MedtrackViewTests` via `./manage.py test patients.tests.MedtrackViewTests`, which passed.
- Ran the full test suite via `./manage.py test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f59d874ac83278282f0fa43880cd5)