### PR TITLE
Show task titles in call-tracking dropdowns

### DIFF
--- a/patients/models.py
+++ b/patients/models.py
@@ -324,6 +324,9 @@ class Task(models.Model):
             self.completed_at = None
         super().save(*args, **kwargs)
 
+    def __str__(self) -> str:
+        return self.title
+
 
 class CaseActivityLog(models.Model):
     case = models.ForeignKey(Case, on_delete=models.CASCADE, related_name="activity_logs")

--- a/patients/tests.py
+++ b/patients/tests.py
@@ -66,6 +66,21 @@ class MedtrackModelTests(TestCase):
         task.save()
         self.assertIsNotNone(task.completed_at)
 
+    def test_task_string_representation_uses_title(self):
+        case = Case.objects.create(
+            uhid="UH101",
+            first_name="B",
+            last_name="Two",
+            phone_number="9999999998",
+            category=self.anc,
+            lmp=timezone.localdate() - timedelta(days=70),
+            edd=timezone.localdate() + timedelta(days=200),
+            created_by=self.user,
+        )
+        task = Task.objects.create(case=case, title="ECG", due_date=timezone.localdate(), created_by=self.user)
+
+        self.assertEqual(str(task), "ECG")
+
 
 class MedtrackViewTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
### Motivation
- Call-tracking and other model-backed selects were rendering options as `Task object (<id>)` because `Task` had no readable string representation, which is confusing for users selecting tasks.

### Description
- Added `Task.__str__` to return the task `title` and added a regression unit test `test_task_string_representation_uses_title` to ensure `str(task)` returns the title; attempted a UI smoke-test but Chromium/Playwright crashed in this environment and Docker/Postgres were unavailable for full end-to-end validation.

### Testing
- Ran `SECRET_KEY=change-me DATABASE_URL=sqlite:////tmp/patient-registry-test.sqlite3 python manage.py test patients.tests.MedtrackModelTests.test_task_string_representation_uses_title` which passed, and ran `SECRET_KEY=change-me DATABASE_URL=sqlite:////tmp/patient-registry-check.sqlite3 python manage.py check` and `SECRET_KEY=change-me DATABASE_URL=sqlite:////tmp/patient-registry-ui.sqlite3 python manage.py migrate`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fc4c844d883278ad02bba307f0d95)