### PR TITLE
Mobile case creation: real API + full-parity wizard

### DIFF
--- a/android/app/src/main/java/com/naveenhospital/medtrack/MedtrackApp.kt
+++ b/android/app/src/main/java/com/naveenhospital/medtrack/MedtrackApp.kt
@@ -1574,8 +1574,6 @@ private fun QuickAddSheet(
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val pathways = categoryOptions.quickAddPathways()
     var searchQuery by remember { mutableStateOf("") }
-    var selectedPathwayLabel by remember(pathways) { mutableStateOf(pathways.firstOrNull()?.label) }
-    val selectedPathway = pathways.firstOrNull { it.label == selectedPathwayLabel }
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
@@ -1600,7 +1598,7 @@ private fun QuickAddSheet(
                         fontWeight = FontWeight.Bold,
                     )
                     Text(
-                        text = "Search patient first, or start a native mock case.",
+                        text = "Search for a patient, or start a new case.",
                         color = MedtrackColors.Muted,
                         style = MaterialTheme.typography.bodySmall,
                     )
@@ -1614,32 +1612,15 @@ private fun QuickAddSheet(
                 onSearch = onOpenHomeSearch,
             )
 
-            MedtrackSectionTitle(title = "Pathways")
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
-                pathways.chunked(2).forEach { rowPathways ->
-                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
-                        rowPathways.forEach { pathway ->
-                            QuickAddPathway(
-                                pathway = pathway,
-                                selected = pathway.label == selectedPathwayLabel,
-                                onClick = { selectedPathwayLabel = pathway.label },
-                                modifier = Modifier.weight(1f),
-                            )
-                        }
-                        if (rowPathways.size == 1) {
-                            Spacer(modifier = Modifier.weight(1f))
-                        }
-                    }
+            MedtrackSectionTitle(title = "Start a new case")
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
+                pathways.forEach { pathway ->
+                    QuickAddPathway(
+                        pathway = pathway,
+                        onClick = { onCreateCase(pathway) },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
                 }
-            }
-
-            Button(
-                onClick = { selectedPathway?.let(onCreateCase) },
-                enabled = selectedPathway != null,
-                modifier = Modifier.fillMaxWidth(),
-                colors = ButtonDefaults.buttonColors(containerColor = MedtrackColors.Ink),
-            ) {
-                Text(selectedPathway?.let { "Continue \u00B7 ${it.label}" } ?: "Continue")
             }
         }
     }
@@ -1698,7 +1679,6 @@ private fun QuickAddSearchBar(
 @Composable
 private fun QuickAddPathway(
     pathway: QuickAddPathwaySpec,
-    selected: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -1706,55 +1686,54 @@ private fun QuickAddPathway(
     Surface(
         modifier = modifier.clickable(onClick = onClick),
         shape = RoundedCornerShape(16.dp),
-        color = if (selected) color.copy(alpha = 0.14f) else MedtrackColors.Card,
-        border = BorderStroke(1.dp, if (selected) color.copy(alpha = 0.42f) else MedtrackColors.Border),
+        color = MedtrackColors.Card,
+        border = BorderStroke(1.dp, MedtrackColors.Border),
     ) {
-        Box(modifier = Modifier.padding(12.dp)) {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(9.dp),
+        Row(
+            modifier = Modifier.padding(start = 12.dp, end = 12.dp, top = 12.dp, bottom = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Surface(
+                modifier = Modifier.size(46.dp),
+                shape = RoundedCornerShape(13.dp),
+                color = color.copy(alpha = 0.14f),
             ) {
-                Surface(
-                    modifier = Modifier.size(42.dp),
-                    shape = RoundedCornerShape(12.dp),
-                    color = color.copy(alpha = 0.14f),
-                ) {
-                    Box(contentAlignment = Alignment.Center) {
-                        Icon(
-                            painter = painterResource(pathway.iconResId),
-                            contentDescription = null,
-                            tint = color,
-                            modifier = Modifier.size(24.dp),
-                        )
-                    }
-                }
-                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                    Text(
-                        text = pathway.label,
-                        color = if (selected) color else MedtrackColors.Ink,
-                        style = MaterialTheme.typography.titleSmall,
-                        fontWeight = FontWeight.ExtraBold,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    Text(
-                        text = pathway.description,
-                        color = MedtrackColors.Muted,
-                        style = MaterialTheme.typography.labelMedium,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        painter = painterResource(pathway.iconResId),
+                        contentDescription = null,
+                        tint = color,
+                        modifier = Modifier.size(24.dp),
                     )
                 }
             }
-            if (selected) {
-                Icon(
-                    imageVector = Icons.Outlined.CheckCircle,
-                    contentDescription = null,
-                    tint = color,
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .size(21.dp),
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                Text(
+                    text = pathway.label,
+                    color = MedtrackColors.Ink,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.ExtraBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = pathway.description,
+                    color = MedtrackColors.Muted,
+                    style = MaterialTheme.typography.labelMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
+            Icon(
+                imageVector = Icons.Outlined.ChevronRight,
+                contentDescription = null,
+                tint = color,
+                modifier = Modifier.size(22.dp),
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/naveenhospital/medtrack/MedtrackApp.kt
+++ b/android/app/src/main/java/com/naveenhospital/medtrack/MedtrackApp.kt
@@ -375,6 +375,7 @@ fun MedtrackApp(
                     MedtrackBottomBar(
                         currentRoute = if (currentRoute == Routes.NOTIFICATIONS) Routes.HOME else currentRoute,
                         unreadCount = shellNotifications.count { !it.isRead },
+                        canQuickAdd = currentUserProfile?.capabilities?.get("case_create") ?: true,
                         onNavigate = ::navigateTopLevel,
                         onQuickAdd = { showQuickAddSheet = true },
                     )
@@ -1097,18 +1098,16 @@ fun MedtrackApp(
                     CaseCreationScreen(
                         modifier = Modifier.fillMaxSize(),
                         pathwayLabel = label,
-                        category = category,
+                        initialCategory = category,
+                        loadMetadata = { container.medtrackRepository.loadCaseFormMetadata() },
+                        searchPatients = { query -> container.medtrackRepository.searchPatients(query) },
+                        submit = { input -> container.medtrackRepository.createCase(input) },
                         onBack = { navController.popBackStack() },
-                        onDraftSaved = { patientName ->
+                        onCreated = { caseId, message ->
                             scope.launch {
-                                snackbarHostState.showSnackbar("Draft saved for $patientName")
+                                snackbarHostState.showSnackbar(message)
                             }
-                        },
-                        onCreated = { patientName ->
-                            scope.launch {
-                                snackbarHostState.showSnackbar("Mock case created for $patientName")
-                            }
-                            navController.navigate(Routes.HOME) {
+                            navController.navigate(Routes.caseDetail(caseId.toString())) {
                                 popUpTo(Routes.HOME) { inclusive = false }
                                 launchSingleTop = true
                             }
@@ -1425,6 +1424,7 @@ fun MedtrackApp(
 private fun MedtrackBottomBar(
     currentRoute: String?,
     unreadCount: Int,
+    canQuickAdd: Boolean,
     onNavigate: (String) -> Unit,
     onQuickAdd: () -> Unit,
 ) {
@@ -1461,37 +1461,39 @@ private fun MedtrackBottomBar(
                 )
             }
         }
-        Surface(
-            modifier = Modifier
-                .align(Alignment.TopCenter)
-                .offset(y = BottomNavScale.CenterButtonYOffset)
-                .size(BottomNavScale.CenterButtonSize),
-            shape = RoundedCornerShape(BottomNavScale.CenterButtonRadius),
-            color = Color.Transparent,
-            shadowElevation = MedtrackElevation.Fab,
-        ) {
-            Box(
+        if (canQuickAdd) {
+            Surface(
                 modifier = Modifier
-                    .fillMaxSize()
-                    .background(
-                        brush = Brush.linearGradient(
-                            listOf(
-                                MedtrackColors.Primary,
-                                MedtrackColors.PrimaryDark,
-                                MedtrackColors.PrimaryDeep,
-                            ),
-                        ),
-                        shape = RoundedCornerShape(BottomNavScale.CenterButtonRadius),
-                    )
-                    .clickable(onClick = onQuickAdd),
-                contentAlignment = Alignment.Center,
+                    .align(Alignment.TopCenter)
+                    .offset(y = BottomNavScale.CenterButtonYOffset)
+                    .size(BottomNavScale.CenterButtonSize),
+                shape = RoundedCornerShape(BottomNavScale.CenterButtonRadius),
+                color = Color.Transparent,
+                shadowElevation = MedtrackElevation.Fab,
             ) {
-                Icon(
-                    imageVector = Icons.Outlined.Add,
-                    contentDescription = "Quick add",
-                    modifier = Modifier.size(BottomNavScale.CenterIconSize),
-                    tint = Color.White,
-                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(
+                            brush = Brush.linearGradient(
+                                listOf(
+                                    MedtrackColors.Primary,
+                                    MedtrackColors.PrimaryDark,
+                                    MedtrackColors.PrimaryDeep,
+                                ),
+                            ),
+                            shape = RoundedCornerShape(BottomNavScale.CenterButtonRadius),
+                        )
+                        .clickable(onClick = onQuickAdd),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Add,
+                        contentDescription = "Quick add",
+                        modifier = Modifier.size(BottomNavScale.CenterIconSize),
+                        tint = Color.White,
+                    )
+                }
             }
         }
     }

--- a/android/core/data/src/main/java/com/naveenhospital/medtrack/core/data/repository/MedtrackRepository.kt
+++ b/android/core/data/src/main/java/com/naveenhospital/medtrack/core/data/repository/MedtrackRepository.kt
@@ -27,9 +27,15 @@ import com.naveenhospital.medtrack.core.data.sync.PendingWriteJson
 import com.naveenhospital.medtrack.core.data.sync.PendingWriteTypes
 import com.naveenhospital.medtrack.core.data.sync.NotificationReadPayload
 import com.naveenhospital.medtrack.core.domain.model.CaseCategory
+import com.naveenhospital.medtrack.core.domain.model.CaseCreateOutcome
+import com.naveenhospital.medtrack.core.domain.model.CaseFormCategory
+import com.naveenhospital.medtrack.core.domain.model.CaseFormMetadata
 import com.naveenhospital.medtrack.core.domain.model.CaseStatus
 import com.naveenhospital.medtrack.core.domain.model.CategoryFilterOption
+import com.naveenhospital.medtrack.core.domain.model.FormChoice
 import com.naveenhospital.medtrack.core.domain.model.InboxStats
+import com.naveenhospital.medtrack.core.domain.model.NewCaseInput
+import com.naveenhospital.medtrack.core.domain.model.PatientLookup
 import com.naveenhospital.medtrack.core.domain.model.NotificationItem
 import com.naveenhospital.medtrack.core.domain.model.PatientCase
 import com.naveenhospital.medtrack.core.domain.model.PatientTask
@@ -39,8 +45,13 @@ import com.naveenhospital.medtrack.core.domain.model.SyncConflict
 import com.naveenhospital.medtrack.core.domain.model.VitalsThresholdConfig
 import com.naveenhospital.medtrack.core.domain.model.WriteResult
 import com.naveenhospital.medtrack.core.network.api.MedtrackApi
+import com.naveenhospital.medtrack.core.network.model.CaseCreateErrorDto
+import com.naveenhospital.medtrack.core.network.model.CaseFormMetadataDto
 import com.naveenhospital.medtrack.core.network.model.CategoriesResponseDto
 import com.naveenhospital.medtrack.core.network.model.CaseCategoryDto
+import com.naveenhospital.medtrack.core.network.model.ChoiceDto
+import com.naveenhospital.medtrack.core.network.model.CreateCaseRequestDto
+import com.naveenhospital.medtrack.core.network.model.PatientLookupDto
 import com.naveenhospital.medtrack.core.network.model.CaseListResponseDto
 import com.naveenhospital.medtrack.core.network.model.CaseStatsDto
 import com.naveenhospital.medtrack.core.network.model.CaseSummaryDto
@@ -88,6 +99,8 @@ class MedtrackRepository(
     val hasMoreCases: StateFlow<Boolean> = _hasMoreCases
     private var nextCasePage: Int? = null
     private var activeCaseListKey: String = ""
+    private val caseCreateErrorAdapter =
+        Moshi.Builder().add(KotlinJsonAdapterFactory()).build().adapter(CaseCreateErrorDto::class.java)
 
     val cases: Flow<List<PatientCase>> =
         database.caseDao().observeCases().map { entities -> entities.map { it.toDomain() } }
@@ -204,6 +217,32 @@ class MedtrackRepository(
         _hasMoreCases.value = nextCasePage != null
         database.caseDao().upsertCases(response.results.map { it.toEntity() })
         database.caseStatsDao().upsertStats(response.stats.toEntity(requestedKey))
+    }
+
+    suspend fun loadCaseFormMetadata(): CaseFormMetadata = api.caseFormMetadata().toDomain()
+
+    suspend fun searchPatients(query: String): List<PatientLookup> =
+        api.searchPatients(query = query.trim().ifBlank { null }).results.map { it.toDomain() }
+
+    suspend fun createCase(input: NewCaseInput): CaseCreateOutcome {
+        val request = input.toRequestDto(newClientWriteId("case"))
+        return runCatching {
+            val response = api.createCase(request)
+            database.caseDao().upsertCase(response.case.toEntity())
+            CaseCreateOutcome.Success(caseId = response.caseId, message = response.message)
+        }.getOrElse { throwable ->
+            if (throwable is HttpException && throwable.code() == 400) {
+                val parsed = runCatching {
+                    caseCreateErrorAdapter.fromJson(throwable.response()?.errorBody()?.string().orEmpty())
+                }.getOrNull()
+                CaseCreateOutcome.ValidationError(
+                    errors = parsed?.errors ?: emptyMap(),
+                    message = parsed?.message ?: "Please fix the highlighted fields.",
+                )
+            } else {
+                throw throwable
+            }
+        }
     }
 
     suspend fun loadCachedCategoryOptions() {
@@ -573,6 +612,89 @@ private class CaseRemoteMediator(
 }
 
 private fun newClientWriteId(prefix: String): String = "$prefix-${UUID.randomUUID()}"
+
+private fun List<ChoiceDto>.toChoices(): List<FormChoice> = map { FormChoice(it.value, it.label) }
+
+private fun CaseFormMetadataDto.toDomain(): CaseFormMetadata = CaseFormMetadata(
+    canCreate = canCreate,
+    categories = categories.map { category ->
+        CaseFormCategory(
+            id = category.id ?: 0L,
+            name = category.name,
+            subcategories = category.subcategories.mapNotNull { sub ->
+                val value = sub.value ?: return@mapNotNull null
+                FormChoice(value = value, label = sub.label ?: value)
+            },
+        )
+    },
+    prefixes = prefixes.toChoices(),
+    bloodGroups = bloodGroups.toChoices(),
+    genders = genders.toChoices(),
+    ncdFlags = ncdFlags.toChoices(),
+    ancHighRiskReasons = ancHighRiskReasons.toChoices(),
+    surgicalPathways = surgicalPathways.toChoices(),
+    reviewFrequencies = reviewFrequencies.toChoices(),
+)
+
+private fun PatientLookupDto.toDomain(): PatientLookup = PatientLookup(
+    id = id,
+    uhid = uhid,
+    name = name.orEmpty(),
+    prefix = prefix.orEmpty(),
+    firstName = firstName.orEmpty(),
+    lastName = lastName.orEmpty(),
+    gender = gender.orEmpty(),
+    genderLabel = genderLabel.orEmpty(),
+    bloodGroup = bloodGroup.orEmpty(),
+    dateOfBirth = dateOfBirth,
+    age = age,
+    place = place.orEmpty(),
+    phoneNumber = phoneNumber.orEmpty(),
+    alternatePhoneNumber = alternatePhoneNumber.orEmpty(),
+    isTemporaryId = isTemporaryId,
+    activeCaseCount = activeCaseCount,
+)
+
+private fun NewCaseInput.toRequestDto(clientWriteId: String): CreateCaseRequestDto = CreateCaseRequestDto(
+    patientMode = patientMode,
+    selectedPatient = selectedPatientId,
+    useTemporaryUhid = useTemporaryUhid,
+    uhid = uhid,
+    prefix = prefix,
+    firstName = firstName,
+    lastName = lastName,
+    gender = gender,
+    bloodGroup = bloodGroup,
+    dateOfBirth = dateOfBirth,
+    place = place,
+    age = age,
+    phoneNumber = phoneNumber,
+    alternatePhoneNumber = alternatePhoneNumber,
+    category = categoryId,
+    subcategory = subcategory,
+    diagnosis = diagnosis,
+    referredBy = referredBy,
+    notes = notes,
+    highRisk = highRisk,
+    ncdFlags = ncdFlags,
+    ancHighRiskReasons = ancHighRiskReasons,
+    rchNumber = rchNumber,
+    rchBypass = rchBypass,
+    lmp = lmp,
+    edd = edd,
+    usgEdd = usgEdd,
+    surgicalPathway = surgicalPathway,
+    surgeryDate = surgeryDate,
+    reviewFrequency = reviewFrequency,
+    reviewDate = reviewDate,
+    gravida = gravida,
+    para = para,
+    abortions = abortions,
+    living = living,
+    ftnd = ftnd,
+    lscs = lscs,
+    clientWriteId = clientWriteId,
+)
 
 fun caseListCacheKey(
     bucket: String?,

--- a/android/core/data/src/test/java/com/naveenhospital/medtrack/core/data/auth/AuthRepositoryTest.kt
+++ b/android/core/data/src/test/java/com/naveenhospital/medtrack/core/data/auth/AuthRepositoryTest.kt
@@ -180,6 +180,12 @@ private class FakeAuthApi(
 
     override suspend fun caseDetail(caseId: String): CaseDetailDto = unused()
 
+    override suspend fun createCase(request: com.naveenhospital.medtrack.core.network.model.CreateCaseRequestDto): com.naveenhospital.medtrack.core.network.model.CaseCreateResponseDto = unused()
+
+    override suspend fun searchPatients(query: String?, page: Int?): com.naveenhospital.medtrack.core.network.model.PatientSearchResponseDto = unused()
+
+    override suspend fun caseFormMetadata(): com.naveenhospital.medtrack.core.network.model.CaseFormMetadataDto = unused()
+
     override suspend fun completeTask(taskId: String, request: ClientWriteRequestDto): TaskWriteResponseDto = unused()
 
     override suspend fun logCall(caseId: String, request: LogCallRequestDto): CallWriteResponseDto = unused()

--- a/android/core/data/src/test/java/com/naveenhospital/medtrack/core/data/repository/MedtrackRepositoryTest.kt
+++ b/android/core/data/src/test/java/com/naveenhospital/medtrack/core/data/repository/MedtrackRepositoryTest.kt
@@ -487,6 +487,9 @@ private class FakeMedtrackApi(
     }
 
     override suspend fun caseDetail(caseId: String): CaseDetailDto = unused()
+    override suspend fun createCase(request: com.naveenhospital.medtrack.core.network.model.CreateCaseRequestDto): com.naveenhospital.medtrack.core.network.model.CaseCreateResponseDto = unused()
+    override suspend fun searchPatients(query: String?, page: Int?): com.naveenhospital.medtrack.core.network.model.PatientSearchResponseDto = unused()
+    override suspend fun caseFormMetadata(): com.naveenhospital.medtrack.core.network.model.CaseFormMetadataDto = unused()
     override suspend fun completeTask(taskId: String, request: ClientWriteRequestDto): TaskWriteResponseDto {
         completeTaskError?.let { throw it }
         return TaskWriteResponseDto(

--- a/android/core/data/src/test/java/com/naveenhospital/medtrack/core/data/sync/MedtrackSyncWorkerTest.kt
+++ b/android/core/data/src/test/java/com/naveenhospital/medtrack/core/data/sync/MedtrackSyncWorkerTest.kt
@@ -264,6 +264,9 @@ private class FakeSyncApi(
     override suspend fun markNotificationRead(notificationId: String): ApiMessageDto = unused()
     override suspend fun registerPushToken(request: RegisterPushTokenRequestDto): ApiMessageDto = unused()
     override suspend fun categories(): CategoriesResponseDto = unused()
+    override suspend fun createCase(request: com.naveenhospital.medtrack.core.network.model.CreateCaseRequestDto): com.naveenhospital.medtrack.core.network.model.CaseCreateResponseDto = unused()
+    override suspend fun searchPatients(query: String?, page: Int?): com.naveenhospital.medtrack.core.network.model.PatientSearchResponseDto = unused()
+    override suspend fun caseFormMetadata(): com.naveenhospital.medtrack.core.network.model.CaseFormMetadataDto = unused()
 
     private fun unused(): Nothing = error("Not used by this test")
 

--- a/android/core/domain/src/main/java/com/naveenhospital/medtrack/core/domain/model/CaseCreation.kt
+++ b/android/core/domain/src/main/java/com/naveenhospital/medtrack/core/domain/model/CaseCreation.kt
@@ -1,0 +1,98 @@
+package com.naveenhospital.medtrack.core.domain.model
+
+/** A single selectable option (server value + human label) for a form menu. */
+data class FormChoice(
+    val value: String,
+    val label: String,
+)
+
+data class CaseFormCategory(
+    val id: Long,
+    val name: String,
+    val subcategories: List<FormChoice>,
+)
+
+/** Everything the case-creation wizard needs to render its menus, driven by the server. */
+data class CaseFormMetadata(
+    val canCreate: Boolean,
+    val categories: List<CaseFormCategory>,
+    val prefixes: List<FormChoice>,
+    val bloodGroups: List<FormChoice>,
+    val genders: List<FormChoice>,
+    val ncdFlags: List<FormChoice>,
+    val ancHighRiskReasons: List<FormChoice>,
+    val surgicalPathways: List<FormChoice>,
+    val reviewFrequencies: List<FormChoice>,
+)
+
+data class PatientLookup(
+    val id: Long,
+    val uhid: String,
+    val name: String,
+    val prefix: String,
+    val firstName: String,
+    val lastName: String,
+    val gender: String,
+    val genderLabel: String,
+    val bloodGroup: String,
+    val dateOfBirth: String?,
+    val age: Int?,
+    val place: String,
+    val phoneNumber: String,
+    val alternatePhoneNumber: String,
+    val isTemporaryId: Boolean,
+    val activeCaseCount: Int?,
+)
+
+/** Form payload mirroring the web CaseForm field set. */
+data class NewCaseInput(
+    val patientMode: String,
+    val selectedPatientId: Long? = null,
+    val useTemporaryUhid: Boolean = false,
+    val uhid: String? = null,
+    val prefix: String? = null,
+    val firstName: String? = null,
+    val lastName: String? = null,
+    val gender: String? = null,
+    val bloodGroup: String? = null,
+    val dateOfBirth: String? = null,
+    val place: String? = null,
+    val age: Int? = null,
+    val phoneNumber: String? = null,
+    val alternatePhoneNumber: String? = null,
+    val categoryId: Long,
+    val categoryName: String,
+    val subcategory: String? = null,
+    val diagnosis: String? = null,
+    val referredBy: String? = null,
+    val notes: String? = null,
+    val highRisk: Boolean = false,
+    val ncdFlags: List<String> = emptyList(),
+    val ancHighRiskReasons: List<String> = emptyList(),
+    val rchNumber: String? = null,
+    val rchBypass: Boolean = false,
+    val lmp: String? = null,
+    val edd: String? = null,
+    val usgEdd: String? = null,
+    val surgicalPathway: String? = null,
+    val surgeryDate: String? = null,
+    val reviewFrequency: String? = null,
+    val reviewDate: String? = null,
+    val gravida: Int? = null,
+    val para: Int? = null,
+    val abortions: Int? = null,
+    val living: Int? = null,
+    val ftnd: Int? = null,
+    val lscs: Int? = null,
+)
+
+sealed interface CaseCreateOutcome {
+    data class Success(val caseId: Long, val message: String) : CaseCreateOutcome
+
+    data class ValidationError(
+        val errors: Map<String, List<String>>,
+        val message: String,
+    ) : CaseCreateOutcome
+
+    data class Failure(val message: String) : CaseCreateOutcome
+}

--- a/android/core/network/src/main/java/com/naveenhospital/medtrack/core/network/api/MedtrackApi.kt
+++ b/android/core/network/src/main/java/com/naveenhospital/medtrack/core/network/api/MedtrackApi.kt
@@ -3,10 +3,14 @@ package com.naveenhospital.medtrack.core.network.api
 import com.naveenhospital.medtrack.core.network.model.ApiMessageDto
 import com.naveenhospital.medtrack.core.network.model.CategoriesResponseDto
 import com.naveenhospital.medtrack.core.network.model.AuthSessionDto
+import com.naveenhospital.medtrack.core.network.model.CaseCreateResponseDto
 import com.naveenhospital.medtrack.core.network.model.CaseDetailDto
+import com.naveenhospital.medtrack.core.network.model.CaseFormMetadataDto
 import com.naveenhospital.medtrack.core.network.model.CaseListResponseDto
 import com.naveenhospital.medtrack.core.network.model.ClientWriteRequestDto
+import com.naveenhospital.medtrack.core.network.model.CreateCaseRequestDto
 import com.naveenhospital.medtrack.core.network.model.LogCallRequestDto
+import com.naveenhospital.medtrack.core.network.model.PatientSearchResponseDto
 import com.naveenhospital.medtrack.core.network.model.LoginRequestDto
 import com.naveenhospital.medtrack.core.network.model.NotificationsResponseDto
 import com.naveenhospital.medtrack.core.network.model.RefreshTokenRequestDto
@@ -45,6 +49,18 @@ interface MedtrackApi {
         @Query("q") query: String? = null,
         @Query("page") page: Int? = null,
     ): CaseListResponseDto
+
+    @POST("api/cases/")
+    suspend fun createCase(@Body request: CreateCaseRequestDto): CaseCreateResponseDto
+
+    @GET("api/patients/")
+    suspend fun searchPatients(
+        @Query("q") query: String? = null,
+        @Query("page") page: Int? = null,
+    ): PatientSearchResponseDto
+
+    @GET("api/metadata/case-form/")
+    suspend fun caseFormMetadata(): CaseFormMetadataDto
 
     @GET("api/cases/{caseId}/")
     suspend fun caseDetail(@Path("caseId") caseId: String): CaseDetailDto

--- a/android/core/network/src/main/java/com/naveenhospital/medtrack/core/network/model/ApiDtos.kt
+++ b/android/core/network/src/main/java/com/naveenhospital/medtrack/core/network/model/ApiDtos.kt
@@ -191,3 +191,100 @@ data class CategoriesResponseDto(
 data class ApiMessageDto(
     val message: String? = null,
 )
+
+data class ChoiceDto(
+    val value: String,
+    val label: String,
+)
+
+data class CaseFormMetadataDto(
+    @Json(name = "can_create") val canCreate: Boolean = false,
+    val categories: List<CaseCategoryDto> = emptyList(),
+    val prefixes: List<ChoiceDto> = emptyList(),
+    @Json(name = "blood_groups") val bloodGroups: List<ChoiceDto> = emptyList(),
+    val genders: List<ChoiceDto> = emptyList(),
+    @Json(name = "ncd_flags") val ncdFlags: List<ChoiceDto> = emptyList(),
+    @Json(name = "anc_high_risk_reasons") val ancHighRiskReasons: List<ChoiceDto> = emptyList(),
+    @Json(name = "surgical_pathways") val surgicalPathways: List<ChoiceDto> = emptyList(),
+    @Json(name = "review_frequencies") val reviewFrequencies: List<ChoiceDto> = emptyList(),
+)
+
+data class PatientSearchResponseDto(
+    val count: Int = 0,
+    val next: String? = null,
+    val previous: String? = null,
+    val results: List<PatientLookupDto> = emptyList(),
+)
+
+data class PatientLookupDto(
+    val id: Long,
+    val uhid: String,
+    val name: String?,
+    val prefix: String?,
+    @Json(name = "first_name") val firstName: String?,
+    @Json(name = "last_name") val lastName: String?,
+    val gender: String?,
+    @Json(name = "gender_label") val genderLabel: String?,
+    @Json(name = "blood_group") val bloodGroup: String?,
+    @Json(name = "date_of_birth") val dateOfBirth: String?,
+    val age: Int?,
+    val place: String?,
+    @Json(name = "phone_number") val phoneNumber: String?,
+    @Json(name = "alternate_phone_number") val alternatePhoneNumber: String?,
+    @Json(name = "is_temporary_id") val isTemporaryId: Boolean = false,
+    @Json(name = "active_case_count") val activeCaseCount: Int? = null,
+    @Json(name = "total_case_count") val totalCaseCount: Int? = null,
+)
+
+data class CreateCaseRequestDto(
+    @Json(name = "patient_mode") val patientMode: String,
+    @Json(name = "selected_patient") val selectedPatient: Long? = null,
+    @Json(name = "use_temporary_uhid") val useTemporaryUhid: Boolean = false,
+    val uhid: String? = null,
+    val prefix: String? = null,
+    @Json(name = "first_name") val firstName: String? = null,
+    @Json(name = "last_name") val lastName: String? = null,
+    val gender: String? = null,
+    @Json(name = "blood_group") val bloodGroup: String? = null,
+    @Json(name = "date_of_birth") val dateOfBirth: String? = null,
+    val place: String? = null,
+    val age: Int? = null,
+    @Json(name = "phone_number") val phoneNumber: String? = null,
+    @Json(name = "alternate_phone_number") val alternatePhoneNumber: String? = null,
+    val category: Long,
+    val subcategory: String? = null,
+    val diagnosis: String? = null,
+    @Json(name = "referred_by") val referredBy: String? = null,
+    val notes: String? = null,
+    @Json(name = "high_risk") val highRisk: Boolean = false,
+    @Json(name = "ncd_flags") val ncdFlags: List<String> = emptyList(),
+    @Json(name = "anc_high_risk_reasons") val ancHighRiskReasons: List<String> = emptyList(),
+    @Json(name = "rch_number") val rchNumber: String? = null,
+    @Json(name = "rch_bypass") val rchBypass: Boolean = false,
+    val lmp: String? = null,
+    val edd: String? = null,
+    @Json(name = "usg_edd") val usgEdd: String? = null,
+    @Json(name = "surgical_pathway") val surgicalPathway: String? = null,
+    @Json(name = "surgery_done") val surgeryDone: Boolean = false,
+    @Json(name = "surgery_date") val surgeryDate: String? = null,
+    @Json(name = "review_frequency") val reviewFrequency: String? = null,
+    @Json(name = "review_date") val reviewDate: String? = null,
+    val gravida: Int? = null,
+    val para: Int? = null,
+    val abortions: Int? = null,
+    val living: Int? = null,
+    val ftnd: Int? = null,
+    val lscs: Int? = null,
+    @Json(name = "client_write_id") val clientWriteId: String,
+)
+
+data class CaseCreateResponseDto(
+    val message: String,
+    @Json(name = "case_id") val caseId: Long,
+    val case: CaseSummaryDto,
+)
+
+data class CaseCreateErrorDto(
+    val message: String? = null,
+    val errors: Map<String, List<String>> = emptyMap(),
+)

--- a/android/feature/case/src/main/java/com/naveenhospital/medtrack/feature/case/CaseCreationScreen.kt
+++ b/android/feature/case/src/main/java/com/naveenhospital/medtrack/feature/case/CaseCreationScreen.kt
@@ -21,15 +21,18 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.ArrowForward
+import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.ExpandMore
+import androidx.compose.material.icons.outlined.Remove
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DatePicker
@@ -190,7 +193,7 @@ private fun CaseCreationForm(
             item {
                 when (stepTitles.getOrNull(step)) {
                     "Patient" -> PatientStep(state)
-                    "Clinical" -> ClinicalStep(state, pathwayColor)
+                    "Clinical" -> ClinicalStep(state)
                     "ANC", "Surgery", "Medicine" -> PathwayStep(state)
                     else -> ReviewStep(state)
                 }
@@ -320,21 +323,21 @@ private fun NewPatientFields(state: CaseFormState) {
             onChange = { state.useTemporaryUhid = it },
         )
         if (!state.useTemporaryUhid) {
-            TextField("UHID", state.uhid) { state.uhid = it }
+            TextField("UHID", state.uhid, required = true) { state.uhid = it }
         }
         FieldRow {
-            DropdownField("Prefix", state.prefix, state.metadata.prefixes, { state.prefix = it }, Modifier.weight(1f))
-            TextField("First name", state.firstName, Modifier.weight(1.6f)) { state.firstName = it }
+            DropdownField("Prefix", state.prefix, state.metadata.prefixes, { state.prefix = it }, Modifier.weight(1f), required = true)
+            TextField("First name", state.firstName, Modifier.weight(1.6f), required = true) { state.firstName = it }
         }
-        TextField("Last name", state.lastName) { state.lastName = it }
+        TextField("Last name", state.lastName, required = true) { state.lastName = it }
         FieldRow {
-            DropdownField("Sex", state.gender, state.metadata.genders, { state.gender = it }, Modifier.weight(1f))
-            TextField("Age", state.age, Modifier.weight(0.8f), keyboard = KeyboardType.Number) {
+            DropdownField("Sex", state.gender, state.metadata.genders, { state.gender = it }, Modifier.weight(1f), required = true)
+            TextField("Age", state.age, Modifier.weight(0.8f), required = true, keyboard = KeyboardType.Number) {
                 state.age = it.filter(Char::isDigit).take(3)
             }
         }
         FieldRow {
-            TextField("Phone", state.phone, Modifier.weight(1.3f), keyboard = KeyboardType.Phone) {
+            TextField("Phone", state.phone, Modifier.weight(1.3f), required = true, keyboard = KeyboardType.Phone) {
                 state.phone = it.filter(Char::isDigit).take(10)
             }
             DropdownField("Blood group", state.bloodGroup, state.metadata.bloodGroups, { state.bloodGroup = it }, Modifier.weight(1f), optional = true)
@@ -345,15 +348,13 @@ private fun NewPatientFields(state: CaseFormState) {
 
 @Composable
 @OptIn(ExperimentalLayoutApi::class)
-private fun ClinicalStep(state: CaseFormState, categoryColor: Color) {
+private fun ClinicalStep(state: CaseFormState) {
     val category = state.category
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        // Chosen category shown read-only (picked in quick-add)
-        ReadonlyField(label = "Category", value = category?.name ?: "-", tint = categoryColor)
         if (category != null && category.subcategories.isNotEmpty()) {
-            DropdownField("Subcategory", state.subcategory, category.subcategories, { state.subcategory = it })
+            DropdownField("Subcategory", state.subcategory, category.subcategories, { state.subcategory = it }, required = true)
         }
-        MultilineField("Diagnosis / reason", state.diagnosis) { state.diagnosis = it }
+        MultilineField("Diagnosis / reason", state.diagnosis, required = true) { state.diagnosis = it }
         TextField("Referred by", state.referredBy, optional = true) { state.referredBy = it }
         ToggleRow(
             label = "High risk",
@@ -376,21 +377,23 @@ private fun PathwayStep(state: CaseFormState) {
             category.name.isAnc() -> {
                 MedtrackSectionTitle(title = "Obstetric history (GPLA)")
                 FieldRow {
-                    GplaField("G", state.gravida, { state.gravida = it }, Modifier.weight(1f))
-                    GplaField("P", state.para, { state.para = it }, Modifier.weight(1f))
-                    GplaField("A", state.abortions, { state.abortions = it }, Modifier.weight(1f))
-                    GplaField("L", state.living, { state.living = it }, Modifier.weight(1f))
+                    StepperField("Gravida", state.gravida, { state.gravida = it }, Modifier.weight(1f))
+                    StepperField("Para", state.para, { state.para = it }, Modifier.weight(1f))
                 }
                 FieldRow {
-                    GplaField("FTND", state.ftnd, { state.ftnd = it }, Modifier.weight(1f))
-                    GplaField("LSCS", state.lscs, { state.lscs = it }, Modifier.weight(1f))
-                    Spacer(Modifier.weight(2f))
+                    StepperField("Abortions", state.abortions, { state.abortions = it }, Modifier.weight(1f))
+                    StepperField("Living", state.living, { state.living = it }, Modifier.weight(1f))
+                }
+                FieldRow {
+                    StepperField("FTND", state.ftnd, { state.ftnd = it }, Modifier.weight(1f))
+                    StepperField("LSCS", state.lscs, { state.lscs = it }, Modifier.weight(1f))
                 }
                 MedtrackSectionTitle(title = "Pregnancy dates")
-                DateField("LMP", state.lmp) { state.lmp = it }
+                DateField("LMP", state.lmp, required = true) { state.lmp = it }
+                val eddNeeded = state.edd.isBlank() && state.usgEdd.isBlank()
                 FieldRow {
-                    DateField("EDD", state.edd, Modifier.weight(1f)) { state.edd = it }
-                    DateField("USG EDD", state.usgEdd, Modifier.weight(1f)) { state.usgEdd = it }
+                    DateField("EDD", state.edd, Modifier.weight(1f), required = eddNeeded || state.edd.isNotBlank()) { state.edd = it }
+                    DateField("USG EDD", state.usgEdd, Modifier.weight(1f), required = eddNeeded || state.usgEdd.isNotBlank()) { state.usgEdd = it }
                 }
                 MedtrackSectionTitle(title = "RCH")
                 ToggleRow(
@@ -400,7 +403,7 @@ private fun PathwayStep(state: CaseFormState) {
                     onChange = { state.rchBypass = it },
                 )
                 if (!state.rchBypass) {
-                    TextField("RCH number", state.rchNumber, keyboard = KeyboardType.Number) {
+                    TextField("RCH number", state.rchNumber, required = true, keyboard = KeyboardType.Number) {
                         state.rchNumber = it.filter(Char::isDigit)
                     }
                 }
@@ -411,16 +414,16 @@ private fun PathwayStep(state: CaseFormState) {
             }
             category.name.isSurgery() -> {
                 MedtrackSectionTitle(title = "Surgical pathway")
-                DropdownField("Pathway", state.surgicalPathway, state.metadata.surgicalPathways, { state.surgicalPathway = it })
+                DropdownField("Pathway", state.surgicalPathway, state.metadata.surgicalPathways, { state.surgicalPathway = it }, required = true)
                 when (state.surgicalPathway) {
-                    "PLANNED_SURGERY" -> DateField("Surgery date", state.surgeryDate) { state.surgeryDate = it }
-                    "SURVEILLANCE" -> DateField("Review date", state.reviewDate) { state.reviewDate = it }
+                    "PLANNED_SURGERY" -> DateField("Surgery date", state.surgeryDate, required = true) { state.surgeryDate = it }
+                    "SURVEILLANCE" -> DateField("Review date", state.reviewDate, required = true) { state.reviewDate = it }
                 }
             }
             else -> {
                 MedtrackSectionTitle(title = "Review schedule")
                 DropdownField("Review frequency", state.reviewFrequency, state.metadata.reviewFrequencies, { state.reviewFrequency = it }, optional = true)
-                DateField("Review date", state.reviewDate) { state.reviewDate = it }
+                DateField("Review date", state.reviewDate, required = true) { state.reviewDate = it }
             }
         }
     }
@@ -483,36 +486,81 @@ private fun FieldRow(content: @Composable () -> Unit) {
     ) { content() }
 }
 
+private enum class FieldStatus { Neutral, Needs, Done }
+
+private fun fieldStatus(required: Boolean, filled: Boolean): FieldStatus =
+    when {
+        !required -> FieldStatus.Neutral
+        filled -> FieldStatus.Done
+        else -> FieldStatus.Needs
+    }
+
+@Composable
+private fun StatusMark(status: FieldStatus) {
+    when (status) {
+        FieldStatus.Needs -> Box(
+            modifier = Modifier
+                .size(7.dp)
+                .background(MedtrackColors.Warning, CircleShape),
+        )
+        FieldStatus.Done -> Icon(
+            Icons.Outlined.Check,
+            contentDescription = null,
+            tint = MedtrackColors.Success,
+            modifier = Modifier.size(13.dp),
+        )
+        FieldStatus.Neutral -> Unit
+    }
+}
+
+@Composable
+private fun FieldLabel(label: String, focused: Boolean, status: FieldStatus) {
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(5.dp)) {
+        Text(
+            label,
+            color = if (focused) MedtrackColors.Primary else MedtrackColors.Faint,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.ExtraBold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        StatusMark(status)
+    }
+}
+
 @Composable
 private fun FieldShell(
     label: String,
     modifier: Modifier = Modifier,
     focused: Boolean = false,
+    status: FieldStatus = FieldStatus.Neutral,
     onClick: (() -> Unit)? = null,
     trailing: (@Composable () -> Unit)? = null,
     content: @Composable () -> Unit,
 ) {
-    val borderColor = if (focused) MedtrackColors.Primary else MedtrackColors.Border
+    val borderColor = when {
+        focused -> MedtrackColors.Primary
+        status == FieldStatus.Needs -> MedtrackColors.Warning.copy(alpha = 0.55f)
+        else -> MedtrackColors.Border
+    }
+    val fill = if (status == FieldStatus.Needs && !focused) {
+        MedtrackColors.WarningSoft.copy(alpha = 0.5f)
+    } else {
+        MedtrackColors.Card
+    }
     Surface(
         modifier = modifier
             .height(FieldHeight)
             .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
         shape = RoundedCornerShape(14.dp),
-        color = MedtrackColors.Card,
+        color = fill,
         border = BorderStroke(1.5.dp, borderColor),
     ) {
         Column(
             modifier = Modifier.padding(horizontal = 13.dp, vertical = 9.dp),
             verticalArrangement = Arrangement.spacedBy(3.dp),
         ) {
-            Text(
-                label,
-                color = if (focused) MedtrackColors.Primary else MedtrackColors.Faint,
-                style = MaterialTheme.typography.labelSmall,
-                fontWeight = FontWeight.ExtraBold,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
+            FieldLabel(label, focused, status)
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                 Box(Modifier.weight(1f)) { content() }
                 trailing?.invoke()
@@ -527,11 +575,17 @@ private fun TextField(
     value: String,
     modifier: Modifier = Modifier,
     optional: Boolean = false,
+    required: Boolean = false,
     keyboard: KeyboardType = KeyboardType.Text,
     onValueChange: (String) -> Unit,
 ) {
     var focused by remember { mutableStateOf(false) }
-    FieldShell(label = if (optional) "$label (optional)" else label, modifier = modifier, focused = focused) {
+    FieldShell(
+        label = if (optional) "$label (optional)" else label,
+        modifier = modifier,
+        focused = focused,
+        status = fieldStatus(required, value.isNotBlank()),
+    ) {
         BasicTextField(
             value = value,
             onValueChange = onValueChange,
@@ -551,26 +605,32 @@ private fun MultilineField(
     label: String,
     value: String,
     optional: Boolean = false,
+    required: Boolean = false,
     onValueChange: (String) -> Unit,
 ) {
     var focused by remember { mutableStateOf(false) }
-    val borderColor = if (focused) MedtrackColors.Primary else MedtrackColors.Border
+    val status = fieldStatus(required, value.isNotBlank())
+    val borderColor = when {
+        focused -> MedtrackColors.Primary
+        status == FieldStatus.Needs -> MedtrackColors.Warning.copy(alpha = 0.55f)
+        else -> MedtrackColors.Border
+    }
+    val fill = if (status == FieldStatus.Needs && !focused) {
+        MedtrackColors.WarningSoft.copy(alpha = 0.5f)
+    } else {
+        MedtrackColors.Card
+    }
     Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(14.dp),
-        color = MedtrackColors.Card,
+        color = fill,
         border = BorderStroke(1.5.dp, borderColor),
     ) {
         Column(
             modifier = Modifier.padding(horizontal = 13.dp, vertical = 9.dp),
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            Text(
-                if (optional) "$label (optional)" else label,
-                color = if (focused) MedtrackColors.Primary else MedtrackColors.Faint,
-                style = MaterialTheme.typography.labelSmall,
-                fontWeight = FontWeight.ExtraBold,
-            )
+            FieldLabel(if (optional) "$label (optional)" else label, focused, status)
             BasicTextField(
                 value = value,
                 onValueChange = onValueChange,
@@ -586,26 +646,6 @@ private fun MultilineField(
 }
 
 @Composable
-private fun ReadonlyField(label: String, value: String, tint: Color) {
-    Surface(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(FieldHeight),
-        shape = RoundedCornerShape(14.dp),
-        color = tint.copy(alpha = 0.08f),
-        border = BorderStroke(1.dp, tint.copy(alpha = 0.28f)),
-    ) {
-        Column(
-            modifier = Modifier.padding(horizontal = 13.dp, vertical = 9.dp),
-            verticalArrangement = Arrangement.spacedBy(3.dp),
-        ) {
-            Text(label, color = MedtrackColors.Faint, style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.ExtraBold)
-            Text(value, color = tint, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.ExtraBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
-        }
-    }
-}
-
-@Composable
 @OptIn(ExperimentalMaterial3Api::class)
 private fun DropdownField(
     label: String,
@@ -614,6 +654,7 @@ private fun DropdownField(
     onSelect: (String) -> Unit,
     modifier: Modifier = Modifier,
     optional: Boolean = false,
+    required: Boolean = false,
 ) {
     var expanded by remember { mutableStateOf(false) }
     val selectedLabel = options.firstOrNull { it.value == value }?.label
@@ -621,6 +662,7 @@ private fun DropdownField(
         FieldShell(
             label = if (optional) "$label (optional)" else label,
             focused = expanded,
+            status = fieldStatus(required, value.isNotBlank()),
             onClick = { expanded = true },
             trailing = { Icon(Icons.Outlined.ExpandMore, contentDescription = null, tint = MedtrackColors.Faint, modifier = Modifier.size(20.dp)) },
         ) {
@@ -648,16 +690,69 @@ private fun DropdownField(
 }
 
 @Composable
-private fun GplaField(label: String, value: Int?, onSelect: (Int?) -> Unit, modifier: Modifier = Modifier) {
-    val options = remember { (0..10).map { FormChoice(it.toString(), it.toString()) } }
-    DropdownField(label, value?.toString() ?: "", options, { onSelect(it.toIntOrNull()) }, modifier)
+private fun StepButton(add: Boolean, enabled: Boolean, onClick: () -> Unit) {
+    Surface(
+        modifier = Modifier
+            .size(30.dp)
+            .clickable(enabled = enabled, onClick = onClick),
+        shape = CircleShape,
+        color = if (enabled) MedtrackColors.PrimarySoft else MedtrackColors.SurfaceAlt,
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Icon(
+                if (add) Icons.Outlined.Add else Icons.Outlined.Remove,
+                contentDescription = if (add) "Increase" else "Decrease",
+                tint = if (enabled) MedtrackColors.Primary else MedtrackColors.Faint,
+                modifier = Modifier.size(17.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun StepperField(label: String, value: Int?, onChange: (Int) -> Unit, modifier: Modifier = Modifier) {
+    val current = value ?: 0
+    Surface(
+        modifier = modifier.height(FieldHeight),
+        shape = RoundedCornerShape(14.dp),
+        color = MedtrackColors.Card,
+        border = BorderStroke(1.5.dp, MedtrackColors.Border),
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 7.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                label,
+                color = MedtrackColors.Faint,
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.ExtraBold,
+                maxLines = 1,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                StepButton(add = false, enabled = current > 0) { onChange((current - 1).coerceAtLeast(0)) }
+                Text(
+                    current.toString(),
+                    color = MedtrackColors.Ink,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.ExtraBold,
+                )
+                StepButton(add = true, enabled = current < 10) { onChange((current + 1).coerceAtMost(10)) }
+            }
+        }
+    }
 }
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
-private fun DateField(label: String, value: String, modifier: Modifier = Modifier, onChange: (String) -> Unit) {
+private fun DateField(label: String, value: String, modifier: Modifier = Modifier, required: Boolean = false, onChange: (String) -> Unit) {
     var open by remember { mutableStateOf(false) }
-    FieldShell(label = label, modifier = modifier, onClick = { open = true }) {
+    FieldShell(label = label, modifier = modifier, status = fieldStatus(required, value.isNotBlank()), onClick = { open = true }) {
         Text(
             value.ifBlank { "Select date" },
             color = if (value.isBlank()) MedtrackColors.Faint else MedtrackColors.Ink,

--- a/android/feature/case/src/main/java/com/naveenhospital/medtrack/feature/case/CaseCreationScreen.kt
+++ b/android/feature/case/src/main/java/com/naveenhospital/medtrack/feature/case/CaseCreationScreen.kt
@@ -21,64 +21,128 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.ArrowForward
 import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.Close
-import androidx.compose.material.icons.outlined.CloudDone
-import androidx.compose.material.icons.outlined.Event
-import androidx.compose.material.icons.outlined.HealthAndSafety
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material.icons.outlined.ExpandMore
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.naveenhospital.medtrack.core.designsystem.MedtrackColors
 import com.naveenhospital.medtrack.core.designsystem.MedtrackSectionTitle
-import com.naveenhospital.medtrack.core.designsystem.R as DesignR
 import com.naveenhospital.medtrack.core.domain.model.CaseCategory
+import com.naveenhospital.medtrack.core.domain.model.CaseCreateOutcome
+import com.naveenhospital.medtrack.core.domain.model.CaseFormCategory
+import com.naveenhospital.medtrack.core.domain.model.CaseFormMetadata
+import com.naveenhospital.medtrack.core.domain.model.FormChoice
+import com.naveenhospital.medtrack.core.domain.model.NewCaseInput
+import com.naveenhospital.medtrack.core.domain.model.PatientLookup
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
 import java.util.Locale
+import java.util.TimeZone
+
+private fun String.isAnc() = trim().equals("ANC", ignoreCase = true)
+private fun String.isSurgery() = trim().equals("Surgery", ignoreCase = true)
+
+@Composable
+fun CaseCreationScreen(
+    initialCategory: CaseCategory,
+    pathwayLabel: String,
+    loadMetadata: suspend () -> CaseFormMetadata,
+    searchPatients: suspend (String) -> List<PatientLookup>,
+    submit: suspend (NewCaseInput) -> CaseCreateOutcome,
+    onBack: () -> Unit,
+    onCreated: (Long, String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val scope = rememberCoroutineScope()
+    var metadata by remember { mutableStateOf<CaseFormMetadata?>(null) }
+    var loadError by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(Unit) {
+        runCatching { loadMetadata() }
+            .onSuccess { metadata = it }
+            .onFailure { loadError = it.message ?: "Unable to load form" }
+    }
+
+    val meta = metadata
+    when {
+        loadError != null -> CenterState(title = "Couldn't load the form", subtitle = loadError, onBack = onBack)
+        meta == null -> CenterState(title = "Loading form…", subtitle = null, onBack = onBack, loading = true)
+        !meta.canCreate -> CenterState(
+            title = "No permission",
+            subtitle = "Your role can't create cases. Ask an administrator for access.",
+            onBack = onBack,
+        )
+        else -> CaseCreationForm(
+            metadata = meta,
+            initialCategory = initialCategory,
+            pathwayLabel = pathwayLabel,
+            searchPatients = searchPatients,
+            onBack = onBack,
+            onSubmit = { input, onResult ->
+                scope.launch {
+                    val outcome = runCatching { submit(input) }.getOrElse {
+                        CaseCreateOutcome.Failure(it.message ?: "Network error. Try again.")
+                    }
+                    onResult(outcome)
+                }
+            },
+            onCreated = onCreated,
+            modifier = modifier,
+        )
+    }
+}
 
 @Composable
 @OptIn(ExperimentalLayoutApi::class)
-fun CaseCreationScreen(
+private fun CaseCreationForm(
+    metadata: CaseFormMetadata,
+    initialCategory: CaseCategory,
     pathwayLabel: String,
-    category: CaseCategory,
+    searchPatients: suspend (String) -> List<PatientLookup>,
     onBack: () -> Unit,
-    onDraftSaved: (String) -> Unit,
-    onCreated: (String) -> Unit,
+    onSubmit: (NewCaseInput, (CaseCreateOutcome) -> Unit) -> Unit,
+    onCreated: (Long, String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var step by rememberSaveable { mutableStateOf(0) }
-    var fullName by rememberSaveable { mutableStateOf("Keerthana Manikandan") }
-    var phone by rememberSaveable { mutableStateOf("+91 98xxx 41200") }
-    var age by rememberSaveable { mutableStateOf("27") }
-    var sex by rememberSaveable { mutableStateOf("Female") }
-    var district by rememberSaveable { mutableStateOf("Coimbatore") }
-    var clinicalSummary by rememberSaveable { mutableStateOf(defaultClinicalSummary(category)) }
-    var scheduleStart by rememberSaveable { mutableStateOf("Today") }
-    var cadence by rememberSaveable { mutableStateOf("Weekly follow-up") }
-    var selectedFlags by rememberSaveable {
-        mutableStateOf(setOf("Advanced maternal age", "Anaemia"))
-    }
-    val uhid = "auto \u00B7 ${district.toDistrictPrefix()}-26\u2026"
-    val pathwayColor = category.handoffColor()
-    val canContinue = fullName.isNotBlank() && phone.isNotBlank() && age.toIntOrNull() != null
-    val steps = listOf("Patient", "Clinical", "Schedule")
+    val state = remember { CaseFormState(metadata, initialCategory) }
+    state.searchPatients = searchPatients
+    var step by remember { mutableStateOf(0) }
+    var submitting by remember { mutableStateOf(false) }
+    var banner by remember { mutableStateOf<String?>(null) }
+
+    val category = state.category
+    val stepTitles = remember(category?.name) { state.stepTitles() }
+    val pathwayColor = category?.name.handoffColor()
 
     Column(
         modifier = modifier
@@ -106,10 +170,10 @@ fun CaseCreationScreen(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
-            CategoryChip(label = pathwayLabel, category = category, color = pathwayColor)
+            CategoryChip(label = category?.name ?: pathwayLabel, color = pathwayColor)
         }
 
-        Stepper(steps = steps, currentStep = step)
+        Stepper(steps = stepTitles, currentStep = step)
 
         LazyColumn(
             modifier = Modifier
@@ -119,90 +183,123 @@ fun CaseCreationScreen(
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             item {
-                when (step) {
-                    0 -> PatientStep(
-                        fullName = fullName,
-                        onFullNameChange = { fullName = it },
-                        phone = phone,
-                        onPhoneChange = { phone = it },
-                        age = age,
-                        onAgeChange = { age = it.filter(Char::isDigit).take(3) },
-                        sex = sex,
-                        onSexChange = { sex = it },
-                        district = district,
-                        onDistrictChange = { district = it },
-                        uhid = uhid,
-                        selectedFlags = selectedFlags,
-                        onToggleFlag = { flag ->
-                            selectedFlags = if (flag in selectedFlags) selectedFlags - flag else selectedFlags + flag
-                        },
-                    )
-                    1 -> ClinicalStep(
-                        category = category,
-                        pathwayLabel = pathwayLabel,
-                        clinicalSummary = clinicalSummary,
-                        onClinicalSummaryChange = { clinicalSummary = it },
-                        selectedFlags = selectedFlags,
-                        onToggleFlag = { flag ->
-                            selectedFlags = if (flag in selectedFlags) selectedFlags - flag else selectedFlags + flag
-                        },
-                    )
-                    else -> ScheduleStep(
-                        scheduleStart = scheduleStart,
-                        onScheduleStartChange = { scheduleStart = it },
-                        cadence = cadence,
-                        onCadenceChange = { cadence = it },
-                        patientName = fullName.ifBlank { "New patient" },
-                        pathwayLabel = pathwayLabel,
-                        selectedFlags = selectedFlags,
-                    )
+                banner?.let { BannerError(it) }
+                when (stepTitles.getOrNull(step)) {
+                    "Patient" -> PatientStep(state)
+                    "Clinical" -> ClinicalStep(state)
+                    "ANC", "Surgery", "Medicine" -> PathwayStep(state)
+                    else -> ReviewStep(state)
                 }
             }
         }
 
-        Surface(
-            modifier = Modifier.fillMaxWidth(),
-            color = MedtrackColors.Card,
-            border = BorderStroke(1.dp, MedtrackColors.Border.copy(alpha = 0.72f)),
-        ) {
-            Row(
-                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 12.dp, bottom = 16.dp),
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
-            ) {
-                Button(
-                    onClick = { onDraftSaved(fullName.ifBlank { "Draft case" }) },
-                    modifier = Modifier.height(52.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MedtrackColors.Card,
-                        contentColor = MedtrackColors.InkSoft,
-                    ),
-                    border = BorderStroke(1.dp, MedtrackColors.Border),
-                    contentPadding = PaddingValues(horizontal = 18.dp),
-                ) {
-                    Text("Save draft", fontWeight = FontWeight.Bold)
+        BottomBar(
+            primaryLabel = if (step < stepTitles.lastIndex) "Continue · ${stepTitles[step + 1]}" else "Create case",
+            primaryEnabled = !submitting,
+            submitting = submitting && step == stepTitles.lastIndex,
+            showBack = step > 0,
+            onBack = { if (step > 0) step -= 1 },
+            onPrimary = {
+                banner = null
+                val stepError = state.validateStep(stepTitles[step])
+                if (stepError != null) {
+                    banner = stepError
+                    return@BottomBar
                 }
-                Button(
-                    onClick = {
-                        if (step < steps.lastIndex) {
-                            step += 1
-                        } else {
-                            onCreated(fullName.ifBlank { "New patient" })
+                if (step < stepTitles.lastIndex) {
+                    step += 1
+                } else {
+                    submitting = true
+                    onSubmit(state.toInput()) { outcome ->
+                        submitting = false
+                        when (outcome) {
+                            is CaseCreateOutcome.Success -> onCreated(outcome.caseId, outcome.message)
+                            is CaseCreateOutcome.ValidationError -> banner = outcome.bannerText()
+                            is CaseCreateOutcome.Failure -> banner = outcome.message
                         }
-                    },
-                    enabled = canContinue,
-                    modifier = Modifier
-                        .weight(1f)
-                        .height(52.dp),
-                    colors = ButtonDefaults.buttonColors(containerColor = MedtrackColors.Primary),
-                    contentPadding = PaddingValues(horizontal = 12.dp),
-                ) {
-                    val label = if (step < steps.lastIndex) "Continue \u00B7 ${steps[step + 1]}" else "Create mock case"
-                    Text(label, maxLines = 1, overflow = TextOverflow.Ellipsis, fontWeight = FontWeight.ExtraBold)
-                    Spacer(modifier = Modifier.width(7.dp))
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Outlined.ArrowForward,
-                        contentDescription = null,
-                        modifier = Modifier.size(19.dp),
+                    }
+                }
+            },
+        )
+    }
+}
+
+private fun CaseCreateOutcome.ValidationError.bannerText(): String {
+    val details = errors.values.flatten().take(4)
+    return if (details.isEmpty()) message else details.joinToString("  •  ")
+}
+
+/* ----------------------------- Steps ----------------------------- */
+
+@Composable
+@OptIn(ExperimentalLayoutApi::class)
+private fun PatientStep(state: CaseFormState) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        MedtrackSectionTitle(title = "Patient")
+        SegmentedToggle(
+            options = listOf("New patient" to "new", "Existing patient" to "existing"),
+            selected = state.patientMode,
+            onSelect = { state.patientMode = it },
+        )
+        if (state.patientMode == "existing") {
+            ExistingPatientPicker(state)
+        } else {
+            NewPatientFields(state)
+        }
+    }
+}
+
+@Composable
+private fun ExistingPatientPicker(state: CaseFormState) {
+    val scope = rememberCoroutineScope()
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        OutlinedTextField(
+            value = state.patientQuery,
+            onValueChange = {
+                state.patientQuery = it
+                scope.launch {
+                    state.searching = true
+                    state.patientResults = runCatching { state.searchPatients(it) }.getOrDefault(emptyList())
+                    state.searching = false
+                }
+            },
+            label = { Text("Search UHID, name or phone") },
+            leadingIcon = { Icon(Icons.Outlined.Search, contentDescription = null) },
+            singleLine = true,
+            colors = fieldColors(),
+            shape = RoundedCornerShape(14.dp),
+            modifier = Modifier.fillMaxWidth(),
+        )
+        if (state.searching) {
+            Text("Searching…", color = MedtrackColors.Faint, style = MaterialTheme.typography.bodySmall)
+        }
+        state.selectedPatient?.let { picked ->
+            Surface(
+                shape = RoundedCornerShape(14.dp),
+                color = MedtrackColors.PrimarySoft,
+                border = BorderStroke(1.dp, MedtrackColors.Primary.copy(alpha = 0.4f)),
+            ) {
+                Column(modifier = Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                    Text(picked.name.ifBlank { "Patient" }, color = MedtrackColors.Ink, fontWeight = FontWeight.ExtraBold)
+                    Text("${picked.uhid}  •  ${picked.genderLabel}  •  ${picked.age ?: "-"}y", color = MedtrackColors.Muted, style = MaterialTheme.typography.bodySmall)
+                }
+            }
+        }
+        state.patientResults.take(6).forEach { patient ->
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { state.selectPatient(patient) },
+                shape = RoundedCornerShape(13.dp),
+                color = MedtrackColors.Card,
+                border = BorderStroke(1.dp, MedtrackColors.Border),
+            ) {
+                Column(modifier = Modifier.padding(13.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    Text(patient.name.ifBlank { "Unnamed" }, color = MedtrackColors.Ink, fontWeight = FontWeight.Bold)
+                    Text(
+                        "${patient.uhid}  •  ${patient.phoneNumber.ifBlank { "no phone" }}",
+                        color = MedtrackColors.Muted,
+                        style = MaterialTheme.typography.bodySmall,
                     )
                 }
             }
@@ -211,15 +308,484 @@ fun CaseCreationScreen(
 }
 
 @Composable
-private fun IconSquareButton(onClick: () -> Unit, content: @Composable () -> Unit) {
+private fun NewPatientFields(state: CaseFormState) {
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        ToggleRow(
+            label = "Use temporary patient ID",
+            help = "Generate a local ID now; merge the real UHID later.",
+            checked = state.useTemporaryUhid,
+            onChange = { state.useTemporaryUhid = it },
+        )
+        if (!state.useTemporaryUhid) {
+            MedtrackTextField("UHID", state.uhid) { state.uhid = it }
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
+            DropdownField("Prefix", state.prefix, state.metadata.prefixes, { state.prefix = it }, modifier = Modifier.weight(1f))
+            MedtrackTextField("First name", state.firstName, modifier = Modifier.weight(1.6f)) { state.firstName = it }
+        }
+        MedtrackTextField("Last name", state.lastName) { state.lastName = it }
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
+            DropdownField("Sex", state.gender, state.metadata.genders, { state.gender = it }, modifier = Modifier.weight(1f))
+            MedtrackTextField("Age", state.age, keyboard = KeyboardType.Number, modifier = Modifier.weight(0.8f)) {
+                state.age = it.filter(Char::isDigit).take(3)
+            }
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
+            DropdownField("Blood group", state.bloodGroup, state.metadata.bloodGroups, { state.bloodGroup = it }, optional = true, modifier = Modifier.weight(1f))
+            MedtrackTextField("Phone", state.phone, keyboard = KeyboardType.Phone, modifier = Modifier.weight(1.3f)) {
+                state.phone = it.filter { c -> c.isDigit() }.take(10)
+            }
+        }
+        MedtrackTextField("Place / district", state.place) { state.place = it }
+    }
+}
+
+@Composable
+@OptIn(ExperimentalLayoutApi::class)
+private fun ClinicalStep(state: CaseFormState) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        MedtrackSectionTitle(title = "Category")
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            state.metadata.categories.forEach { option ->
+                ChoicePill(
+                    label = option.name,
+                    selected = state.category?.id == option.id,
+                    tint = option.name.handoffColor(),
+                    onClick = { state.selectCategory(option) },
+                )
+            }
+        }
+        val category = state.category
+        if (category != null && category.subcategories.isNotEmpty()) {
+            DropdownField("Subcategory", state.subcategory, category.subcategories, { state.subcategory = it })
+        }
+        MedtrackTextField("Diagnosis / reason", state.diagnosis, minHeight = 76.dp) { state.diagnosis = it }
+        MedtrackTextField("Referred by", state.referredBy, optional = true) { state.referredBy = it }
+        ToggleRow(
+            label = "High risk",
+            help = "Flag this case for closer follow-up.",
+            checked = state.highRisk,
+            onChange = { state.highRisk = it },
+        )
+        MedtrackSectionTitle(title = "Comorbidities (NCD)")
+        MultiSelectChips(
+            options = state.metadata.ncdFlags,
+            selected = state.ncdFlags,
+            onToggle = { state.toggleNcd(it) },
+            tint = MedtrackColors.Medicine,
+        )
+        MedtrackTextField("Notes", state.notes, optional = true, minHeight = 70.dp) { state.notes = it }
+    }
+}
+
+@Composable
+@OptIn(ExperimentalLayoutApi::class)
+private fun PathwayStep(state: CaseFormState) {
+    val category = state.category ?: return
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        when {
+            category.name.isAnc() -> {
+                MedtrackSectionTitle(title = "Obstetric history (GPLA)")
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
+                    GplaField("G", state.gravida, { state.gravida = it }, Modifier.weight(1f))
+                    GplaField("P", state.para, { state.para = it }, Modifier.weight(1f))
+                    GplaField("A", state.abortions, { state.abortions = it }, Modifier.weight(1f))
+                    GplaField("L", state.living, { state.living = it }, Modifier.weight(1f))
+                }
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
+                    GplaField("FTND", state.ftnd, { state.ftnd = it }, Modifier.weight(1f))
+                    GplaField("LSCS", state.lscs, { state.lscs = it }, Modifier.weight(1f))
+                }
+                MedtrackSectionTitle(title = "Dates")
+                DateField("LMP", state.lmp) { state.lmp = it }
+                Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
+                    Box(Modifier.weight(1f)) { DateField("EDD", state.edd) { state.edd = it } }
+                    Box(Modifier.weight(1f)) { DateField("USG EDD", state.usgEdd) { state.usgEdd = it } }
+                }
+                MedtrackSectionTitle(title = "RCH")
+                ToggleRow(
+                    label = "Bypass RCH for now",
+                    help = "Skip the RCH number; a reminder task is created.",
+                    checked = state.rchBypass,
+                    onChange = { state.rchBypass = it },
+                )
+                if (!state.rchBypass) {
+                    MedtrackTextField("RCH number", state.rchNumber, keyboard = KeyboardType.Number) {
+                        state.rchNumber = it.filter(Char::isDigit)
+                    }
+                }
+                if (state.highRisk) {
+                    MedtrackSectionTitle(title = "ANC high-risk reasons")
+                    MultiSelectChips(
+                        options = state.metadata.ancHighRiskReasons,
+                        selected = state.ancReasons,
+                        onToggle = { state.toggleAncReason(it) },
+                        tint = MedtrackColors.Danger,
+                    )
+                }
+            }
+            category.name.isSurgery() -> {
+                MedtrackSectionTitle(title = "Surgical pathway")
+                DropdownField("Pathway", state.surgicalPathway, state.metadata.surgicalPathways, { state.surgicalPathway = it })
+                if (state.surgicalPathway == "PLANNED_SURGERY") {
+                    DateField("Surgery date", state.surgeryDate) { state.surgeryDate = it }
+                } else if (state.surgicalPathway == "SURVEILLANCE") {
+                    DateField("Review date", state.reviewDate) { state.reviewDate = it }
+                }
+            }
+            else -> {
+                MedtrackSectionTitle(title = "Review schedule")
+                DropdownField("Review frequency", state.reviewFrequency, state.metadata.reviewFrequencies, { state.reviewFrequency = it }, optional = true)
+                DateField("Review date", state.reviewDate) { state.reviewDate = it }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReviewStep(state: CaseFormState) {
+    val category = state.category
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        MedtrackSectionTitle(title = "Review")
+        Surface(
+            shape = RoundedCornerShape(16.dp),
+            color = MedtrackColors.Card,
+            border = BorderStroke(1.dp, MedtrackColors.Border),
+        ) {
+            Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                ReviewRow("Patient", state.reviewPatientLine())
+                ReviewRow("Category", category?.name ?: "-")
+                state.subcategoryLabel()?.let { ReviewRow("Subcategory", it) }
+                ReviewRow("Diagnosis", state.diagnosis.ifBlank { "-" })
+                if (state.highRisk) ReviewRow("Risk", "High risk")
+                state.pathwaySummary()?.let { ReviewRow("Pathway", it) }
+            }
+        }
+        Text(
+            "Submitting creates the case on the server and seeds its starter tasks.",
+            color = MedtrackColors.Muted,
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}
+
+@Composable
+private fun ReviewRow(label: String, value: String) {
+    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(label, color = MedtrackColors.Faint, style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.ExtraBold, modifier = Modifier.width(96.dp))
+        Text(value, color = MedtrackColors.Ink, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
+    }
+}
+
+/* ----------------------------- Reusable fields ----------------------------- */
+
+@Composable
+private fun MedtrackTextField(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+    optional: Boolean = false,
+    keyboard: KeyboardType = KeyboardType.Text,
+    minHeight: androidx.compose.ui.unit.Dp = 0.dp,
+    onValueChange: (String) -> Unit,
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        label = { Text(if (optional) "$label (optional)" else label) },
+        singleLine = minHeight == 0.dp,
+        keyboardOptions = KeyboardOptions(keyboardType = keyboard),
+        colors = fieldColors(),
+        shape = RoundedCornerShape(14.dp),
+        modifier = modifier
+            .fillMaxWidth()
+            .let { if (minHeight > 0.dp) it.height(minHeight) else it },
+    )
+}
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+private fun DropdownField(
+    label: String,
+    value: String,
+    options: List<FormChoice>,
+    onSelect: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    optional: Boolean = false,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val selectedLabel = options.firstOrNull { it.value == value }?.label ?: ""
+    Box(modifier = modifier) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { expanded = true },
+            shape = RoundedCornerShape(14.dp),
+            color = MedtrackColors.Card,
+            border = BorderStroke(1.5.dp, if (expanded) MedtrackColors.Primary else MedtrackColors.Border),
+        ) {
+            Column(modifier = Modifier.padding(horizontal = 13.dp, vertical = 10.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(
+                    if (optional) "$label (optional)" else label,
+                    color = MedtrackColors.Faint,
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.ExtraBold,
+                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        selectedLabel.ifBlank { "Select" },
+                        color = if (selectedLabel.isBlank()) MedtrackColors.Faint else MedtrackColors.Ink,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Icon(Icons.Outlined.ExpandMore, contentDescription = null, tint = MedtrackColors.Faint, modifier = Modifier.size(20.dp))
+                }
+            }
+        }
+        androidx.compose.material3.DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            options.forEach { option ->
+                androidx.compose.material3.DropdownMenuItem(
+                    text = { Text(option.label) },
+                    onClick = {
+                        onSelect(option.value)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GplaField(label: String, value: Int?, onSelect: (Int?) -> Unit, modifier: Modifier = Modifier) {
+    val options = remember { (0..10).map { FormChoice(it.toString(), it.toString()) } }
+    DropdownField(
+        label = label,
+        value = value?.toString() ?: "",
+        options = options,
+        onSelect = { onSelect(it.toIntOrNull()) },
+        modifier = modifier,
+    )
+}
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+private fun DateField(label: String, value: String, onChange: (String) -> Unit) {
+    var open by remember { mutableStateOf(false) }
     Surface(
-        modifier = Modifier.size(42.dp),
-        shape = RoundedCornerShape(12.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { open = true },
+        shape = RoundedCornerShape(14.dp),
         color = MedtrackColors.Card,
-        border = BorderStroke(1.dp, MedtrackColors.Border),
+        border = BorderStroke(1.5.dp, MedtrackColors.Border),
     ) {
-        Box(modifier = Modifier.clickable(onClick = onClick), contentAlignment = Alignment.Center) {
-            content()
+        Column(modifier = Modifier.padding(horizontal = 13.dp, vertical = 10.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(label, color = MedtrackColors.Faint, style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.ExtraBold)
+            Text(
+                value.ifBlank { "Select date" },
+                color = if (value.isBlank()) MedtrackColors.Faint else MedtrackColors.Ink,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+    }
+    if (open) {
+        val pickerState = rememberDatePickerState()
+        DatePickerDialog(
+            onDismissRequest = { open = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    pickerState.selectedDateMillis?.let { onChange(it.toIsoDate()) }
+                    open = false
+                }) { Text("OK") }
+            },
+            dismissButton = { TextButton(onClick = { open = false }) { Text("Cancel") } },
+        ) {
+            DatePicker(state = pickerState)
+        }
+    }
+}
+
+@Composable
+@OptIn(ExperimentalLayoutApi::class)
+private fun MultiSelectChips(options: List<FormChoice>, selected: Set<String>, onToggle: (String) -> Unit, tint: Color) {
+    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        options.forEach { option ->
+            ChoicePill(label = option.label, selected = option.value in selected, tint = tint, onClick = { onToggle(option.value) })
+        }
+    }
+}
+
+@Composable
+private fun ChoicePill(label: String, selected: Boolean, tint: Color, onClick: () -> Unit) {
+    Surface(
+        modifier = Modifier.clickable(onClick = onClick),
+        shape = RoundedCornerShape(50),
+        color = if (selected) tint else MedtrackColors.Card,
+        border = BorderStroke(1.dp, if (selected) tint else MedtrackColors.Border),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (selected) {
+                Icon(Icons.Outlined.Check, contentDescription = null, tint = Color.White, modifier = Modifier.size(15.dp))
+            }
+            Text(
+                label,
+                color = if (selected) Color.White else MedtrackColors.InkSoft,
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SegmentedToggle(options: List<Pair<String, String>>, selected: String, onSelect: (String) -> Unit) {
+    Surface(
+        shape = RoundedCornerShape(14.dp),
+        color = MedtrackColors.SurfaceAlt,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(modifier = Modifier.padding(4.dp), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+            options.forEach { (label, value) ->
+                val active = value == selected
+                Surface(
+                    modifier = Modifier
+                        .weight(1f)
+                        .clickable { onSelect(value) },
+                    shape = RoundedCornerShape(11.dp),
+                    color = if (active) MedtrackColors.Card else Color.Transparent,
+                    border = if (active) BorderStroke(1.dp, MedtrackColors.Border) else null,
+                ) {
+                    Box(modifier = Modifier.padding(vertical = 10.dp), contentAlignment = Alignment.Center) {
+                        Text(
+                            label,
+                            color = if (active) MedtrackColors.Ink else MedtrackColors.Muted,
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.ExtraBold,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ToggleRow(label: String, help: String, checked: Boolean, onChange: (Boolean) -> Unit) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onChange(!checked) },
+        shape = RoundedCornerShape(14.dp),
+        color = MedtrackColors.Card,
+        border = BorderStroke(1.dp, if (checked) MedtrackColors.Primary else MedtrackColors.Border),
+    ) {
+        Row(
+            modifier = Modifier.padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(label, color = MedtrackColors.Ink, fontWeight = FontWeight.Bold)
+                Text(help, color = MedtrackColors.Faint, style = MaterialTheme.typography.bodySmall)
+            }
+            Surface(
+                modifier = Modifier.size(width = 46.dp, height = 28.dp),
+                shape = RoundedCornerShape(50),
+                color = if (checked) MedtrackColors.Primary else MedtrackColors.Border,
+            ) {
+                Box(contentAlignment = if (checked) Alignment.CenterEnd else Alignment.CenterStart) {
+                    Surface(
+                        modifier = Modifier
+                            .padding(3.dp)
+                            .size(22.dp),
+                        shape = RoundedCornerShape(50),
+                        color = Color.White,
+                    ) {}
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BannerError(text: String) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = 4.dp),
+        shape = RoundedCornerShape(13.dp),
+        color = MedtrackColors.DangerSoft,
+        border = BorderStroke(1.dp, MedtrackColors.Danger.copy(alpha = 0.4f)),
+    ) {
+        Text(
+            text,
+            modifier = Modifier.padding(13.dp),
+            color = MedtrackColors.Danger,
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+@Composable
+private fun BottomBar(
+    primaryLabel: String,
+    primaryEnabled: Boolean,
+    submitting: Boolean,
+    showBack: Boolean,
+    onBack: () -> Unit,
+    onPrimary: () -> Unit,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MedtrackColors.Card,
+        border = BorderStroke(1.dp, MedtrackColors.Border.copy(alpha = 0.72f)),
+    ) {
+        Row(
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 12.dp, bottom = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            if (showBack) {
+                Surface(
+                    modifier = Modifier
+                        .height(52.dp)
+                        .clickable(onClick = onBack),
+                    shape = RoundedCornerShape(14.dp),
+                    color = MedtrackColors.Card,
+                    border = BorderStroke(1.dp, MedtrackColors.Border),
+                ) {
+                    Row(modifier = Modifier.padding(horizontal = 18.dp).fillMaxSize(), verticalAlignment = Alignment.CenterVertically) {
+                        Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Back", tint = MedtrackColors.InkSoft, modifier = Modifier.size(18.dp))
+                    }
+                }
+            }
+            Surface(
+                modifier = Modifier
+                    .weight(1f)
+                    .height(52.dp)
+                    .clickable(enabled = primaryEnabled, onClick = onPrimary),
+                shape = RoundedCornerShape(14.dp),
+                color = if (primaryEnabled) MedtrackColors.Primary else MedtrackColors.Faint,
+            ) {
+                Row(modifier = Modifier.fillMaxSize(), horizontalArrangement = Arrangement.Center, verticalAlignment = Alignment.CenterVertically) {
+                    if (submitting) {
+                        CircularProgressIndicator(color = Color.White, strokeWidth = 2.dp, modifier = Modifier.size(18.dp))
+                    } else {
+                        Text(primaryLabel, color = Color.White, fontWeight = FontWeight.ExtraBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        Spacer(Modifier.width(7.dp))
+                        Icon(Icons.AutoMirrored.Outlined.ArrowForward, contentDescription = null, tint = Color.White, modifier = Modifier.size(19.dp))
+                    }
+                }
+            }
         }
     }
 }
@@ -247,36 +813,21 @@ private fun Stepper(steps: List<String>, currentStep: Int) {
             ) {
                 Box(contentAlignment = Alignment.Center) {
                     if (done) {
-                        Icon(imageVector = Icons.Outlined.Check, contentDescription = null, tint = Color.White, modifier = Modifier.size(15.dp))
+                        Icon(Icons.Outlined.Check, contentDescription = null, tint = Color.White, modifier = Modifier.size(15.dp))
                     } else {
-                        Text(
-                            text = (index + 1).toString(),
-                            color = if (current) Color.White else MedtrackColors.Faint,
-                            style = MaterialTheme.typography.labelSmall,
-                            fontWeight = FontWeight.ExtraBold,
-                        )
+                        Text((index + 1).toString(), color = if (current) Color.White else MedtrackColors.Faint, style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.ExtraBold)
                     }
                 }
             }
-            Text(
-                text = label,
-                color = when {
-                    current -> MedtrackColors.Ink
-                    done -> MedtrackColors.Success
-                    else -> MedtrackColors.Faint
-                },
-                style = MaterialTheme.typography.labelMedium,
-                fontWeight = FontWeight.ExtraBold,
-            )
+            if (current) {
+                Text(label, color = MedtrackColors.Ink, style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.ExtraBold)
+            }
             if (index < steps.lastIndex) {
                 Box(
                     modifier = Modifier
                         .weight(1f)
                         .height(2.dp)
-                        .background(
-                            color = if (done) MedtrackColors.Success else MedtrackColors.Border,
-                            shape = RoundedCornerShape(2.dp),
-                        ),
+                        .background(if (done) MedtrackColors.Success else MedtrackColors.Border, RoundedCornerShape(2.dp)),
                 )
             }
         }
@@ -284,280 +835,76 @@ private fun Stepper(steps: List<String>, currentStep: Int) {
 }
 
 @Composable
-@OptIn(ExperimentalLayoutApi::class)
-private fun PatientStep(
-    fullName: String,
-    onFullNameChange: (String) -> Unit,
-    phone: String,
-    onPhoneChange: (String) -> Unit,
-    age: String,
-    onAgeChange: (String) -> Unit,
-    sex: String,
-    onSexChange: (String) -> Unit,
-    district: String,
-    onDistrictChange: (String) -> Unit,
-    uhid: String,
-    selectedFlags: Set<String>,
-    onToggleFlag: (String) -> Unit,
-) {
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        MedtrackSectionTitle(title = "Patient details")
-        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-            CreateField(label = "Full name", value = fullName, onValueChange = onFullNameChange)
-            CreateField(label = "Phone", value = phone, onValueChange = onPhoneChange)
-            Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
-                CreateField(label = "Age", value = age, onValueChange = onAgeChange, unit = "yrs", modifier = Modifier.weight(0.7f))
-                CreateField(label = "Sex", value = sex, onValueChange = onSexChange, modifier = Modifier.weight(1f))
-            }
-            Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
-                CreateField(label = "District", value = district, onValueChange = onDistrictChange, modifier = Modifier.weight(1f))
-                CreateField(label = "UHID", value = uhid, onValueChange = {}, focused = true, readOnly = true, modifier = Modifier.weight(1f))
-            }
-        }
-        MedtrackSectionTitle(title = "Quick risk flags")
-        RiskFlagGrid(selectedFlags = selectedFlags, onToggleFlag = onToggleFlag)
-        OfflineNotice()
-    }
-}
-
-@Composable
-@OptIn(ExperimentalLayoutApi::class)
-private fun ClinicalStep(
-    category: CaseCategory,
-    pathwayLabel: String,
-    clinicalSummary: String,
-    onClinicalSummaryChange: (String) -> Unit,
-    selectedFlags: Set<String>,
-    onToggleFlag: (String) -> Unit,
-) {
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        MedtrackSectionTitle(title = "Clinical")
-        Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
-            CreateReadout(label = "Pathway", value = pathwayLabel, color = category.handoffColor(), modifier = Modifier.weight(1f))
-            CreateReadout(label = "Status", value = "Active", color = MedtrackColors.Primary, modifier = Modifier.weight(1f))
-        }
-        CreateField(
-            label = if (category == CaseCategory.ANC) "Primary concern" else "Diagnosis / reason",
-            value = clinicalSummary,
-            onValueChange = onClinicalSummaryChange,
-            minHeight = 82.dp,
-        )
-        MedtrackSectionTitle(title = "Risk reasons")
-        RiskFlagGrid(selectedFlags = selectedFlags, onToggleFlag = onToggleFlag)
-        OfflineNotice()
-    }
-}
-
-@Composable
-private fun ScheduleStep(
-    scheduleStart: String,
-    onScheduleStartChange: (String) -> Unit,
-    cadence: String,
-    onCadenceChange: (String) -> Unit,
-    patientName: String,
-    pathwayLabel: String,
-    selectedFlags: Set<String>,
-) {
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        MedtrackSectionTitle(title = "Schedule")
-        Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
-            CreateField(label = "Start", value = scheduleStart, onValueChange = onScheduleStartChange, modifier = Modifier.weight(1f))
-            CreateField(label = "Cadence", value = cadence, onValueChange = onCadenceChange, modifier = Modifier.weight(1f))
-        }
-        Surface(
-            shape = RoundedCornerShape(16.dp),
-            color = MedtrackColors.Card,
-            border = BorderStroke(1.dp, MedtrackColors.Border),
-        ) {
-            Column(modifier = Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(9.dp)) {
-                Row(horizontalArrangement = Arrangement.spacedBy(9.dp), verticalAlignment = Alignment.CenterVertically) {
-                    Icon(imageVector = Icons.Outlined.Event, contentDescription = null, tint = MedtrackColors.Primary, modifier = Modifier.size(21.dp))
-                    Text("Mock case summary", color = MedtrackColors.Ink, fontWeight = FontWeight.ExtraBold)
-                }
-                Text(patientName, color = MedtrackColors.Ink, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.ExtraBold)
-                Text("$pathwayLabel follow-up starts $scheduleStart.", color = MedtrackColors.Muted, style = MaterialTheme.typography.bodyMedium)
-                if (selectedFlags.isNotEmpty()) {
-                    Text("${selectedFlags.size} risk reason(s) will seed the case.", color = MedtrackColors.Danger, style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Bold)
-                }
-            }
-        }
-        OfflineNotice()
-    }
-}
-
-@Composable
-private fun CreateField(
-    label: String,
-    value: String,
-    onValueChange: (String) -> Unit,
-    modifier: Modifier = Modifier,
-    unit: String? = null,
-    focused: Boolean = false,
-    readOnly: Boolean = false,
-    minHeight: androidx.compose.ui.unit.Dp = 58.dp,
-) {
-    val borderColor = if (focused) MedtrackColors.Primary else MedtrackColors.Border
+private fun IconSquareButton(onClick: () -> Unit, content: @Composable () -> Unit) {
     Surface(
-        modifier = modifier.height(minHeight),
-        shape = RoundedCornerShape(13.dp),
+        modifier = Modifier.size(42.dp),
+        shape = RoundedCornerShape(12.dp),
         color = MedtrackColors.Card,
-        border = BorderStroke(1.5.dp, borderColor),
+        border = BorderStroke(1.dp, MedtrackColors.Border),
     ) {
-        Column(
-            modifier = Modifier.padding(horizontal = 13.dp, vertical = 9.dp),
-            verticalArrangement = Arrangement.spacedBy(3.dp),
-        ) {
-            Text(
-                text = label,
-                color = if (focused) MedtrackColors.Primary else MedtrackColors.Faint,
-                style = MaterialTheme.typography.labelSmall,
-                fontWeight = FontWeight.ExtraBold,
-            )
-            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(5.dp)) {
-                BasicTextField(
-                    value = value,
-                    onValueChange = if (readOnly) ({}) else onValueChange,
-                    readOnly = readOnly,
-                    singleLine = minHeight <= 58.dp,
-                    textStyle = MaterialTheme.typography.bodyMedium.copy(
-                        color = if (value.isBlank()) MedtrackColors.Faint else MedtrackColors.Ink,
-                        fontWeight = FontWeight.Bold,
-                    ),
-                    modifier = Modifier.weight(1f),
-                )
-                unit?.let {
-                    Text(it, color = MedtrackColors.Faint, style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.SemiBold)
-                }
-            }
-        }
+        Box(modifier = Modifier.clickable(onClick = onClick), contentAlignment = Alignment.Center) { content() }
     }
 }
 
 @Composable
-private fun CreateReadout(label: String, value: String, color: Color, modifier: Modifier = Modifier) {
-    Surface(
-        modifier = modifier.height(58.dp),
-        shape = RoundedCornerShape(13.dp),
-        color = color.copy(alpha = 0.1f),
-        border = BorderStroke(1.dp, color.copy(alpha = 0.26f)),
-    ) {
-        Column(modifier = Modifier.padding(horizontal = 13.dp, vertical = 9.dp), verticalArrangement = Arrangement.spacedBy(3.dp)) {
-            Text(label, color = MedtrackColors.Faint, style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.ExtraBold)
-            Text(value, color = color, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.ExtraBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
-        }
-    }
-}
-
-@Composable
-@OptIn(ExperimentalLayoutApi::class)
-private fun RiskFlagGrid(selectedFlags: Set<String>, onToggleFlag: (String) -> Unit) {
-    val flags = listOf("Advanced maternal age", "Anaemia", "Prev. C-section", "Hypertension", "Diabetes")
-    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        flags.forEach { flag ->
-            val selected = flag in selectedFlags
-            Surface(
-                modifier = Modifier.clickable { onToggleFlag(flag) },
-                shape = RoundedCornerShape(50),
-                color = if (selected) MedtrackColors.Anc else MedtrackColors.Card,
-                border = BorderStroke(1.dp, if (selected) MedtrackColors.Anc else MedtrackColors.Border),
-            ) {
-                Row(
-                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    if (selected) {
-                        Icon(imageVector = Icons.Outlined.Check, contentDescription = null, tint = Color.White, modifier = Modifier.size(15.dp))
-                    }
-                    Text(
-                        text = flag,
-                        color = if (selected) Color.White else MedtrackColors.InkSoft,
-                        style = MaterialTheme.typography.labelMedium,
-                        fontWeight = FontWeight.Bold,
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun OfflineNotice() {
-    Surface(
-        shape = RoundedCornerShape(13.dp),
-        color = MedtrackColors.PrimarySoft,
-    ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 13.dp, vertical = 12.dp),
-            horizontalArrangement = Arrangement.spacedBy(9.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Icon(imageVector = Icons.Outlined.CloudDone, contentDescription = null, tint = MedtrackColors.Primary, modifier = Modifier.size(20.dp))
-            Text(
-                text = "Saved on-device now, synced when online. No more web detour.",
-                color = MedtrackColors.PrimaryDark,
-                style = MaterialTheme.typography.bodySmall,
-                fontWeight = FontWeight.SemiBold,
-            )
-        }
-    }
-}
-
-@Composable
-private fun CategoryChip(label: String, category: CaseCategory, color: Color) {
+private fun CategoryChip(label: String, color: Color) {
     Surface(
         shape = RoundedCornerShape(50),
         color = color.copy(alpha = 0.12f),
         border = BorderStroke(1.dp, color.copy(alpha = 0.24f)),
     ) {
-        Row(
-            modifier = Modifier.padding(start = 8.dp, end = 11.dp, top = 4.dp, bottom = 4.dp),
-            horizontalArrangement = Arrangement.spacedBy(5.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Icon(
-                painter = painterResource(category.creationIconResId()),
-                contentDescription = null,
-                tint = color,
-                modifier = Modifier.size(16.dp),
-            )
-            Text(label, color = color, style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.Bold)
-        }
+        Text(
+            label,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 5.dp),
+            color = color,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+        )
     }
 }
 
-private fun CaseCategory.creationIconResId(): Int =
-    when (this) {
-        CaseCategory.ANC -> DesignR.drawable.ic_cat_anc
-        CaseCategory.SURGERY -> DesignR.drawable.ic_cat_surgery
-        else -> DesignR.drawable.ic_cat_medicine
+@Composable
+private fun CenterState(title: String, subtitle: String?, onBack: () -> Unit, loading: Boolean = false) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MedtrackColors.Surface)
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        if (loading) {
+            CircularProgressIndicator(color = MedtrackColors.Primary)
+            Spacer(Modifier.height(14.dp))
+        }
+        Text(title, color = MedtrackColors.Ink, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.ExtraBold)
+        subtitle?.let {
+            Spacer(Modifier.height(6.dp))
+            Text(it, color = MedtrackColors.Muted, style = MaterialTheme.typography.bodyMedium)
+        }
+        Spacer(Modifier.height(18.dp))
+        TextButton(onClick = onBack) { Text("Go back") }
     }
+}
 
-private fun CaseCategory.handoffColor(): Color =
-    when (this) {
-        CaseCategory.ANC -> MedtrackColors.Anc
-        CaseCategory.SURGERY -> MedtrackColors.Surgery
-        CaseCategory.MEDICINE -> MedtrackColors.Medicine
+@Composable
+private fun fieldColors() = TextFieldDefaults.colors(
+    focusedContainerColor = MedtrackColors.Card,
+    unfocusedContainerColor = MedtrackColors.Card,
+    focusedIndicatorColor = MedtrackColors.Primary,
+    unfocusedIndicatorColor = MedtrackColors.Border,
+)
+
+private fun String?.handoffColor(): Color =
+    when {
+        this == null -> MedtrackColors.Primary
+        isAnc() -> MedtrackColors.Anc
+        isSurgery() -> MedtrackColors.Surgery
+        trim().equals("Medicine", true) -> MedtrackColors.Medicine
         else -> MedtrackColors.Primary
     }
 
-private fun String.toDistrictPrefix(): String {
-    val district = trim().lowercase(Locale.US)
-    val suffix = when {
-        "coimbatore" in district -> "CBE"
-        "salem" in district -> "SLM"
-        "thanjavur" in district -> "TNJ"
-        "madurai" in district -> "MDU"
-        district.length >= 3 -> district.take(3).uppercase(Locale.US)
-        else -> "CBE"
-    }
-    return "TN-$suffix"
+private fun Long.toIsoDate(): String {
+    val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.US).apply { timeZone = TimeZone.getTimeZone("UTC") }
+    return formatter.format(java.util.Date(this))
 }
-
-private fun defaultClinicalSummary(category: CaseCategory): String =
-    when (category) {
-        CaseCategory.ANC -> "First trimester ANC follow-up"
-        CaseCategory.SURGERY -> "Pre-operative fitness review"
-        CaseCategory.MEDICINE -> "Diabetes follow-up"
-        CaseCategory.OTHER -> "Custom follow-up"
-    }

--- a/android/feature/case/src/main/java/com/naveenhospital/medtrack/feature/case/CaseCreationScreen.kt
+++ b/android/feature/case/src/main/java/com/naveenhospital/medtrack/feature/case/CaseCreationScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -21,6 +22,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
@@ -32,14 +34,14 @@ import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -50,7 +52,9 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
@@ -59,7 +63,6 @@ import com.naveenhospital.medtrack.core.designsystem.MedtrackColors
 import com.naveenhospital.medtrack.core.designsystem.MedtrackSectionTitle
 import com.naveenhospital.medtrack.core.domain.model.CaseCategory
 import com.naveenhospital.medtrack.core.domain.model.CaseCreateOutcome
-import com.naveenhospital.medtrack.core.domain.model.CaseFormCategory
 import com.naveenhospital.medtrack.core.domain.model.CaseFormMetadata
 import com.naveenhospital.medtrack.core.domain.model.FormChoice
 import com.naveenhospital.medtrack.core.domain.model.NewCaseInput
@@ -68,6 +71,8 @@ import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
+
+private val FieldHeight = 64.dp
 
 private fun String.isAnc() = trim().equals("ANC", ignoreCase = true)
 private fun String.isSurgery() = trim().equals("Surgery", ignoreCase = true)
@@ -95,12 +100,12 @@ fun CaseCreationScreen(
 
     val meta = metadata
     when {
-        loadError != null -> CenterState(title = "Couldn't load the form", subtitle = loadError, onBack = onBack)
-        meta == null -> CenterState(title = "Loading form…", subtitle = null, onBack = onBack, loading = true)
+        loadError != null -> CenterState("Couldn't load the form", loadError, onBack)
+        meta == null -> CenterState("Loading form…", null, onBack, loading = true)
         !meta.canCreate -> CenterState(
-            title = "No permission",
-            subtitle = "Your role can't create cases. Ask an administrator for access.",
-            onBack = onBack,
+            "No permission",
+            "Your role can't create cases. Ask an administrator for access.",
+            onBack,
         )
         else -> CaseCreationForm(
             metadata = meta,
@@ -123,7 +128,6 @@ fun CaseCreationScreen(
 }
 
 @Composable
-@OptIn(ExperimentalLayoutApi::class)
 private fun CaseCreationForm(
     metadata: CaseFormMetadata,
     initialCategory: CaseCategory,
@@ -141,7 +145,7 @@ private fun CaseCreationForm(
     var banner by remember { mutableStateOf<String?>(null) }
 
     val category = state.category
-    val stepTitles = remember(category?.name) { state.stepTitles() }
+    val stepTitles = state.stepTitles()
     val pathwayColor = category?.name.handoffColor()
 
     Column(
@@ -151,15 +155,16 @@ private fun CaseCreationForm(
             .imePadding()
             .navigationBarsPadding(),
     ) {
+        // Header
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 14.dp, end = 14.dp, top = 8.dp, bottom = 6.dp),
+                .padding(start = 14.dp, end = 14.dp, top = 10.dp, bottom = 6.dp),
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             IconSquareButton(onClick = onBack) {
-                Icon(imageVector = Icons.Outlined.Close, contentDescription = "Close", tint = MedtrackColors.Ink)
+                Icon(Icons.Outlined.Close, contentDescription = "Close", tint = MedtrackColors.Ink)
             }
             Text(
                 text = "New case",
@@ -170,72 +175,72 @@ private fun CaseCreationForm(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
-            CategoryChip(label = category?.name ?: pathwayLabel, color = pathwayColor)
+            CategoryChip(category?.name ?: pathwayLabel, pathwayColor)
         }
 
-        Stepper(steps = stepTitles, currentStep = step)
+        Stepper(stepTitles, step)
 
         LazyColumn(
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth(),
-            contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 18.dp),
+            contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 4.dp, bottom = 20.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             item {
-                banner?.let { BannerError(it) }
                 when (stepTitles.getOrNull(step)) {
                     "Patient" -> PatientStep(state)
-                    "Clinical" -> ClinicalStep(state)
+                    "Clinical" -> ClinicalStep(state, pathwayColor)
                     "ANC", "Surgery", "Medicine" -> PathwayStep(state)
                     else -> ReviewStep(state)
                 }
             }
         }
 
-        BottomBar(
-            primaryLabel = if (step < stepTitles.lastIndex) "Continue · ${stepTitles[step + 1]}" else "Create case",
-            primaryEnabled = !submitting,
-            submitting = submitting && step == stepTitles.lastIndex,
-            showBack = step > 0,
-            onBack = { if (step > 0) step -= 1 },
-            onPrimary = {
-                banner = null
-                val stepError = state.validateStep(stepTitles[step])
-                if (stepError != null) {
-                    banner = stepError
-                    return@BottomBar
-                }
-                if (step < stepTitles.lastIndex) {
-                    step += 1
-                } else {
-                    submitting = true
-                    onSubmit(state.toInput()) { outcome ->
-                        submitting = false
-                        when (outcome) {
-                            is CaseCreateOutcome.Success -> onCreated(outcome.caseId, outcome.message)
-                            is CaseCreateOutcome.ValidationError -> banner = outcome.bannerText()
-                            is CaseCreateOutcome.Failure -> banner = outcome.message
+        // Fixed bottom area: banner (always visible) + buttons
+        Column(modifier = Modifier.fillMaxWidth()) {
+            banner?.let { BannerError(it) }
+            BottomBar(
+                primaryLabel = if (step < stepTitles.lastIndex) "Continue" else "Create case",
+                submitting = submitting,
+                showBack = step > 0,
+                onBack = { if (step > 0) { banner = null; step -= 1 } },
+                onPrimary = {
+                    banner = null
+                    val stepError = state.validateStep(stepTitles[step])
+                    if (stepError != null) {
+                        banner = stepError
+                        return@BottomBar
+                    }
+                    if (step < stepTitles.lastIndex) {
+                        step += 1
+                    } else {
+                        submitting = true
+                        onSubmit(state.toInput()) { outcome ->
+                            submitting = false
+                            when (outcome) {
+                                is CaseCreateOutcome.Success -> onCreated(outcome.caseId, outcome.message)
+                                is CaseCreateOutcome.ValidationError -> banner = outcome.bannerText()
+                                is CaseCreateOutcome.Failure -> banner = outcome.message
+                            }
                         }
                     }
-                }
-            },
-        )
+                },
+            )
+        }
     }
 }
 
 private fun CaseCreateOutcome.ValidationError.bannerText(): String {
-    val details = errors.values.flatten().take(4)
+    val details = errors.values.flatten().take(3)
     return if (details.isEmpty()) message else details.joinToString("  •  ")
 }
 
 /* ----------------------------- Steps ----------------------------- */
 
 @Composable
-@OptIn(ExperimentalLayoutApi::class)
 private fun PatientStep(state: CaseFormState) {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        MedtrackSectionTitle(title = "Patient")
         SegmentedToggle(
             options = listOf("New patient" to "new", "Existing patient" to "existing"),
             selected = state.patientMode,
@@ -253,7 +258,7 @@ private fun PatientStep(state: CaseFormState) {
 private fun ExistingPatientPicker(state: CaseFormState) {
     val scope = rememberCoroutineScope()
     Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-        OutlinedTextField(
+        SearchField(
             value = state.patientQuery,
             onValueChange = {
                 state.patientQuery = it
@@ -263,27 +268,25 @@ private fun ExistingPatientPicker(state: CaseFormState) {
                     state.searching = false
                 }
             },
-            label = { Text("Search UHID, name or phone") },
-            leadingIcon = { Icon(Icons.Outlined.Search, contentDescription = null) },
-            singleLine = true,
-            colors = fieldColors(),
-            shape = RoundedCornerShape(14.dp),
-            modifier = Modifier.fillMaxWidth(),
         )
-        if (state.searching) {
-            Text("Searching…", color = MedtrackColors.Faint, style = MaterialTheme.typography.bodySmall)
-        }
         state.selectedPatient?.let { picked ->
             Surface(
                 shape = RoundedCornerShape(14.dp),
                 color = MedtrackColors.PrimarySoft,
                 border = BorderStroke(1.dp, MedtrackColors.Primary.copy(alpha = 0.4f)),
             ) {
-                Column(modifier = Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(3.dp)) {
                     Text(picked.name.ifBlank { "Patient" }, color = MedtrackColors.Ink, fontWeight = FontWeight.ExtraBold)
-                    Text("${picked.uhid}  •  ${picked.genderLabel}  •  ${picked.age ?: "-"}y", color = MedtrackColors.Muted, style = MaterialTheme.typography.bodySmall)
+                    Text(
+                        "${picked.uhid}  •  ${picked.genderLabel}  •  ${picked.age ?: "-"}y",
+                        color = MedtrackColors.Muted,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
                 }
             }
+        }
+        if (state.searching) {
+            Text("Searching…", color = MedtrackColors.Faint, style = MaterialTheme.typography.bodySmall)
         }
         state.patientResults.take(6).forEach { patient ->
             Surface(
@@ -294,7 +297,7 @@ private fun ExistingPatientPicker(state: CaseFormState) {
                 color = MedtrackColors.Card,
                 border = BorderStroke(1.dp, MedtrackColors.Border),
             ) {
-                Column(modifier = Modifier.padding(13.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Column(Modifier.padding(13.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
                     Text(patient.name.ifBlank { "Unnamed" }, color = MedtrackColors.Ink, fontWeight = FontWeight.Bold)
                     Text(
                         "${patient.uhid}  •  ${patient.phoneNumber.ifBlank { "no phone" }}",
@@ -312,55 +315,46 @@ private fun NewPatientFields(state: CaseFormState) {
     Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
         ToggleRow(
             label = "Use temporary patient ID",
-            help = "Generate a local ID now; merge the real UHID later.",
+            help = "Generate a local ID now; add the real UHID later.",
             checked = state.useTemporaryUhid,
             onChange = { state.useTemporaryUhid = it },
         )
         if (!state.useTemporaryUhid) {
-            MedtrackTextField("UHID", state.uhid) { state.uhid = it }
+            TextField("UHID", state.uhid) { state.uhid = it }
         }
-        Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
-            DropdownField("Prefix", state.prefix, state.metadata.prefixes, { state.prefix = it }, modifier = Modifier.weight(1f))
-            MedtrackTextField("First name", state.firstName, modifier = Modifier.weight(1.6f)) { state.firstName = it }
+        FieldRow {
+            DropdownField("Prefix", state.prefix, state.metadata.prefixes, { state.prefix = it }, Modifier.weight(1f))
+            TextField("First name", state.firstName, Modifier.weight(1.6f)) { state.firstName = it }
         }
-        MedtrackTextField("Last name", state.lastName) { state.lastName = it }
-        Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
-            DropdownField("Sex", state.gender, state.metadata.genders, { state.gender = it }, modifier = Modifier.weight(1f))
-            MedtrackTextField("Age", state.age, keyboard = KeyboardType.Number, modifier = Modifier.weight(0.8f)) {
+        TextField("Last name", state.lastName) { state.lastName = it }
+        FieldRow {
+            DropdownField("Sex", state.gender, state.metadata.genders, { state.gender = it }, Modifier.weight(1f))
+            TextField("Age", state.age, Modifier.weight(0.8f), keyboard = KeyboardType.Number) {
                 state.age = it.filter(Char::isDigit).take(3)
             }
         }
-        Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
-            DropdownField("Blood group", state.bloodGroup, state.metadata.bloodGroups, { state.bloodGroup = it }, optional = true, modifier = Modifier.weight(1f))
-            MedtrackTextField("Phone", state.phone, keyboard = KeyboardType.Phone, modifier = Modifier.weight(1.3f)) {
-                state.phone = it.filter { c -> c.isDigit() }.take(10)
+        FieldRow {
+            TextField("Phone", state.phone, Modifier.weight(1.3f), keyboard = KeyboardType.Phone) {
+                state.phone = it.filter(Char::isDigit).take(10)
             }
+            DropdownField("Blood group", state.bloodGroup, state.metadata.bloodGroups, { state.bloodGroup = it }, Modifier.weight(1f), optional = true)
         }
-        MedtrackTextField("Place / district", state.place) { state.place = it }
+        TextField("Place / district", state.place, optional = true) { state.place = it }
     }
 }
 
 @Composable
 @OptIn(ExperimentalLayoutApi::class)
-private fun ClinicalStep(state: CaseFormState) {
+private fun ClinicalStep(state: CaseFormState, categoryColor: Color) {
+    val category = state.category
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        MedtrackSectionTitle(title = "Category")
-        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            state.metadata.categories.forEach { option ->
-                ChoicePill(
-                    label = option.name,
-                    selected = state.category?.id == option.id,
-                    tint = option.name.handoffColor(),
-                    onClick = { state.selectCategory(option) },
-                )
-            }
-        }
-        val category = state.category
+        // Chosen category shown read-only (picked in quick-add)
+        ReadonlyField(label = "Category", value = category?.name ?: "-", tint = categoryColor)
         if (category != null && category.subcategories.isNotEmpty()) {
             DropdownField("Subcategory", state.subcategory, category.subcategories, { state.subcategory = it })
         }
-        MedtrackTextField("Diagnosis / reason", state.diagnosis, minHeight = 76.dp) { state.diagnosis = it }
-        MedtrackTextField("Referred by", state.referredBy, optional = true) { state.referredBy = it }
+        MultilineField("Diagnosis / reason", state.diagnosis) { state.diagnosis = it }
+        TextField("Referred by", state.referredBy, optional = true) { state.referredBy = it }
         ToggleRow(
             label = "High risk",
             help = "Flag this case for closer follow-up.",
@@ -368,13 +362,8 @@ private fun ClinicalStep(state: CaseFormState) {
             onChange = { state.highRisk = it },
         )
         MedtrackSectionTitle(title = "Comorbidities (NCD)")
-        MultiSelectChips(
-            options = state.metadata.ncdFlags,
-            selected = state.ncdFlags,
-            onToggle = { state.toggleNcd(it) },
-            tint = MedtrackColors.Medicine,
-        )
-        MedtrackTextField("Notes", state.notes, optional = true, minHeight = 70.dp) { state.notes = it }
+        MultiSelectChips(state.metadata.ncdFlags, state.ncdFlags, { state.toggleNcd(it) }, MedtrackColors.Medicine)
+        MultilineField("Notes", state.notes, optional = true) { state.notes = it }
     }
 }
 
@@ -386,51 +375,46 @@ private fun PathwayStep(state: CaseFormState) {
         when {
             category.name.isAnc() -> {
                 MedtrackSectionTitle(title = "Obstetric history (GPLA)")
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
+                FieldRow {
                     GplaField("G", state.gravida, { state.gravida = it }, Modifier.weight(1f))
                     GplaField("P", state.para, { state.para = it }, Modifier.weight(1f))
                     GplaField("A", state.abortions, { state.abortions = it }, Modifier.weight(1f))
                     GplaField("L", state.living, { state.living = it }, Modifier.weight(1f))
                 }
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
+                FieldRow {
                     GplaField("FTND", state.ftnd, { state.ftnd = it }, Modifier.weight(1f))
                     GplaField("LSCS", state.lscs, { state.lscs = it }, Modifier.weight(1f))
+                    Spacer(Modifier.weight(2f))
                 }
-                MedtrackSectionTitle(title = "Dates")
+                MedtrackSectionTitle(title = "Pregnancy dates")
                 DateField("LMP", state.lmp) { state.lmp = it }
-                Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
-                    Box(Modifier.weight(1f)) { DateField("EDD", state.edd) { state.edd = it } }
-                    Box(Modifier.weight(1f)) { DateField("USG EDD", state.usgEdd) { state.usgEdd = it } }
+                FieldRow {
+                    DateField("EDD", state.edd, Modifier.weight(1f)) { state.edd = it }
+                    DateField("USG EDD", state.usgEdd, Modifier.weight(1f)) { state.usgEdd = it }
                 }
                 MedtrackSectionTitle(title = "RCH")
                 ToggleRow(
                     label = "Bypass RCH for now",
-                    help = "Skip the RCH number; a reminder task is created.",
+                    help = "Skip the number; a reminder task is created.",
                     checked = state.rchBypass,
                     onChange = { state.rchBypass = it },
                 )
                 if (!state.rchBypass) {
-                    MedtrackTextField("RCH number", state.rchNumber, keyboard = KeyboardType.Number) {
+                    TextField("RCH number", state.rchNumber, keyboard = KeyboardType.Number) {
                         state.rchNumber = it.filter(Char::isDigit)
                     }
                 }
                 if (state.highRisk) {
                     MedtrackSectionTitle(title = "ANC high-risk reasons")
-                    MultiSelectChips(
-                        options = state.metadata.ancHighRiskReasons,
-                        selected = state.ancReasons,
-                        onToggle = { state.toggleAncReason(it) },
-                        tint = MedtrackColors.Danger,
-                    )
+                    MultiSelectChips(state.metadata.ancHighRiskReasons, state.ancReasons, { state.toggleAncReason(it) }, MedtrackColors.Danger)
                 }
             }
             category.name.isSurgery() -> {
                 MedtrackSectionTitle(title = "Surgical pathway")
                 DropdownField("Pathway", state.surgicalPathway, state.metadata.surgicalPathways, { state.surgicalPathway = it })
-                if (state.surgicalPathway == "PLANNED_SURGERY") {
-                    DateField("Surgery date", state.surgeryDate) { state.surgeryDate = it }
-                } else if (state.surgicalPathway == "SURVEILLANCE") {
-                    DateField("Review date", state.reviewDate) { state.reviewDate = it }
+                when (state.surgicalPathway) {
+                    "PLANNED_SURGERY" -> DateField("Surgery date", state.surgeryDate) { state.surgeryDate = it }
+                    "SURVEILLANCE" -> DateField("Review date", state.reviewDate) { state.reviewDate = it }
                 }
             }
             else -> {
@@ -446,13 +430,12 @@ private fun PathwayStep(state: CaseFormState) {
 private fun ReviewStep(state: CaseFormState) {
     val category = state.category
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        MedtrackSectionTitle(title = "Review")
         Surface(
             shape = RoundedCornerShape(16.dp),
             color = MedtrackColors.Card,
             border = BorderStroke(1.dp, MedtrackColors.Border),
         ) {
-            Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
                 ReviewRow("Patient", state.reviewPatientLine())
                 ReviewRow("Category", category?.name ?: "-")
                 state.subcategoryLabel()?.let { ReviewRow("Subcategory", it) }
@@ -462,7 +445,7 @@ private fun ReviewStep(state: CaseFormState) {
             }
         }
         Text(
-            "Submitting creates the case on the server and seeds its starter tasks.",
+            "Creating the case saves it on the server and seeds its starter tasks.",
             color = MedtrackColors.Muted,
             style = MaterialTheme.typography.bodySmall,
         )
@@ -472,35 +455,154 @@ private fun ReviewStep(state: CaseFormState) {
 @Composable
 private fun ReviewRow(label: String, value: String) {
     Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-        Text(label, color = MedtrackColors.Faint, style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.ExtraBold, modifier = Modifier.width(96.dp))
-        Text(value, color = MedtrackColors.Ink, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
+        Text(
+            label,
+            color = MedtrackColors.Faint,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.ExtraBold,
+            modifier = Modifier.width(92.dp),
+        )
+        Text(
+            value,
+            color = MedtrackColors.Ink,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.weight(1f),
+        )
     }
 }
 
 /* ----------------------------- Reusable fields ----------------------------- */
 
 @Composable
-private fun MedtrackTextField(
+private fun FieldRow(content: @Composable () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.Top,
+    ) { content() }
+}
+
+@Composable
+private fun FieldShell(
+    label: String,
+    modifier: Modifier = Modifier,
+    focused: Boolean = false,
+    onClick: (() -> Unit)? = null,
+    trailing: (@Composable () -> Unit)? = null,
+    content: @Composable () -> Unit,
+) {
+    val borderColor = if (focused) MedtrackColors.Primary else MedtrackColors.Border
+    Surface(
+        modifier = modifier
+            .height(FieldHeight)
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
+        shape = RoundedCornerShape(14.dp),
+        color = MedtrackColors.Card,
+        border = BorderStroke(1.5.dp, borderColor),
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 13.dp, vertical = 9.dp),
+            verticalArrangement = Arrangement.spacedBy(3.dp),
+        ) {
+            Text(
+                label,
+                color = if (focused) MedtrackColors.Primary else MedtrackColors.Faint,
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.ExtraBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                Box(Modifier.weight(1f)) { content() }
+                trailing?.invoke()
+            }
+        }
+    }
+}
+
+@Composable
+private fun TextField(
     label: String,
     value: String,
     modifier: Modifier = Modifier,
     optional: Boolean = false,
     keyboard: KeyboardType = KeyboardType.Text,
-    minHeight: androidx.compose.ui.unit.Dp = 0.dp,
     onValueChange: (String) -> Unit,
 ) {
-    OutlinedTextField(
-        value = value,
-        onValueChange = onValueChange,
-        label = { Text(if (optional) "$label (optional)" else label) },
-        singleLine = minHeight == 0.dp,
-        keyboardOptions = KeyboardOptions(keyboardType = keyboard),
-        colors = fieldColors(),
+    var focused by remember { mutableStateOf(false) }
+    FieldShell(label = if (optional) "$label (optional)" else label, modifier = modifier, focused = focused) {
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = keyboard),
+            textStyle = MaterialTheme.typography.bodyMedium.copy(color = MedtrackColors.Ink, fontWeight = FontWeight.Bold),
+            cursorBrush = SolidColor(MedtrackColors.Primary),
+            modifier = Modifier
+                .fillMaxWidth()
+                .onFocusChanged { focused = it.isFocused },
+        )
+    }
+}
+
+@Composable
+private fun MultilineField(
+    label: String,
+    value: String,
+    optional: Boolean = false,
+    onValueChange: (String) -> Unit,
+) {
+    var focused by remember { mutableStateOf(false) }
+    val borderColor = if (focused) MedtrackColors.Primary else MedtrackColors.Border
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(14.dp),
-        modifier = modifier
+        color = MedtrackColors.Card,
+        border = BorderStroke(1.5.dp, borderColor),
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 13.dp, vertical = 9.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(
+                if (optional) "$label (optional)" else label,
+                color = if (focused) MedtrackColors.Primary else MedtrackColors.Faint,
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.ExtraBold,
+            )
+            BasicTextField(
+                value = value,
+                onValueChange = onValueChange,
+                textStyle = MaterialTheme.typography.bodyMedium.copy(color = MedtrackColors.Ink, fontWeight = FontWeight.Medium),
+                cursorBrush = SolidColor(MedtrackColors.Primary),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 38.dp)
+                    .onFocusChanged { focused = it.isFocused },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ReadonlyField(label: String, value: String, tint: Color) {
+    Surface(
+        modifier = Modifier
             .fillMaxWidth()
-            .let { if (minHeight > 0.dp) it.height(minHeight) else it },
-    )
+            .height(FieldHeight),
+        shape = RoundedCornerShape(14.dp),
+        color = tint.copy(alpha = 0.08f),
+        border = BorderStroke(1.dp, tint.copy(alpha = 0.28f)),
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 13.dp, vertical = 9.dp),
+            verticalArrangement = Arrangement.spacedBy(3.dp),
+        ) {
+            Text(label, color = MedtrackColors.Faint, style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.ExtraBold)
+            Text(value, color = tint, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.ExtraBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        }
+    }
 }
 
 @Composable
@@ -514,40 +616,26 @@ private fun DropdownField(
     optional: Boolean = false,
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val selectedLabel = options.firstOrNull { it.value == value }?.label ?: ""
+    val selectedLabel = options.firstOrNull { it.value == value }?.label
     Box(modifier = modifier) {
-        Surface(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable { expanded = true },
-            shape = RoundedCornerShape(14.dp),
-            color = MedtrackColors.Card,
-            border = BorderStroke(1.5.dp, if (expanded) MedtrackColors.Primary else MedtrackColors.Border),
+        FieldShell(
+            label = if (optional) "$label (optional)" else label,
+            focused = expanded,
+            onClick = { expanded = true },
+            trailing = { Icon(Icons.Outlined.ExpandMore, contentDescription = null, tint = MedtrackColors.Faint, modifier = Modifier.size(20.dp)) },
         ) {
-            Column(modifier = Modifier.padding(horizontal = 13.dp, vertical = 10.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                Text(
-                    if (optional) "$label (optional)" else label,
-                    color = MedtrackColors.Faint,
-                    style = MaterialTheme.typography.labelSmall,
-                    fontWeight = FontWeight.ExtraBold,
-                )
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(
-                        selectedLabel.ifBlank { "Select" },
-                        color = if (selectedLabel.isBlank()) MedtrackColors.Faint else MedtrackColors.Ink,
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Bold,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f),
-                    )
-                    Icon(Icons.Outlined.ExpandMore, contentDescription = null, tint = MedtrackColors.Faint, modifier = Modifier.size(20.dp))
-                }
-            }
+            Text(
+                selectedLabel ?: "Select",
+                color = if (selectedLabel == null) MedtrackColors.Faint else MedtrackColors.Ink,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
         }
-        androidx.compose.material3.DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             options.forEach { option ->
-                androidx.compose.material3.DropdownMenuItem(
+                DropdownMenuItem(
                     text = { Text(option.label) },
                     onClick = {
                         onSelect(option.value)
@@ -562,36 +650,21 @@ private fun DropdownField(
 @Composable
 private fun GplaField(label: String, value: Int?, onSelect: (Int?) -> Unit, modifier: Modifier = Modifier) {
     val options = remember { (0..10).map { FormChoice(it.toString(), it.toString()) } }
-    DropdownField(
-        label = label,
-        value = value?.toString() ?: "",
-        options = options,
-        onSelect = { onSelect(it.toIntOrNull()) },
-        modifier = modifier,
-    )
+    DropdownField(label, value?.toString() ?: "", options, { onSelect(it.toIntOrNull()) }, modifier)
 }
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
-private fun DateField(label: String, value: String, onChange: (String) -> Unit) {
+private fun DateField(label: String, value: String, modifier: Modifier = Modifier, onChange: (String) -> Unit) {
     var open by remember { mutableStateOf(false) }
-    Surface(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable { open = true },
-        shape = RoundedCornerShape(14.dp),
-        color = MedtrackColors.Card,
-        border = BorderStroke(1.5.dp, MedtrackColors.Border),
-    ) {
-        Column(modifier = Modifier.padding(horizontal = 13.dp, vertical = 10.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
-            Text(label, color = MedtrackColors.Faint, style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.ExtraBold)
-            Text(
-                value.ifBlank { "Select date" },
-                color = if (value.isBlank()) MedtrackColors.Faint else MedtrackColors.Ink,
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Bold,
-            )
-        }
+    FieldShell(label = label, modifier = modifier, onClick = { open = true }) {
+        Text(
+            value.ifBlank { "Select date" },
+            color = if (value.isBlank()) MedtrackColors.Faint else MedtrackColors.Ink,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Bold,
+            maxLines = 1,
+        )
     }
     if (open) {
         val pickerState = rememberDatePickerState()
@@ -604,8 +677,42 @@ private fun DateField(label: String, value: String, onChange: (String) -> Unit) 
                 }) { Text("OK") }
             },
             dismissButton = { TextButton(onClick = { open = false }) { Text("Cancel") } },
+        ) { DatePicker(state = pickerState) }
+    }
+}
+
+@Composable
+private fun SearchField(value: String, onValueChange: (String) -> Unit) {
+    var focused by remember { mutableStateOf(false) }
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(54.dp),
+        shape = RoundedCornerShape(14.dp),
+        color = MedtrackColors.Card,
+        border = BorderStroke(1.5.dp, if (focused) MedtrackColors.Primary else MedtrackColors.Border),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
         ) {
-            DatePicker(state = pickerState)
+            Icon(Icons.Outlined.Search, contentDescription = null, tint = MedtrackColors.Primary, modifier = Modifier.size(20.dp))
+            Box(Modifier.weight(1f)) {
+                if (value.isBlank()) {
+                    Text("Search UHID, name or phone", color = MedtrackColors.Faint, style = MaterialTheme.typography.bodyMedium)
+                }
+                BasicTextField(
+                    value = value,
+                    onValueChange = onValueChange,
+                    singleLine = true,
+                    textStyle = MaterialTheme.typography.bodyMedium.copy(color = MedtrackColors.Ink, fontWeight = FontWeight.Bold),
+                    cursorBrush = SolidColor(MedtrackColors.Primary),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .onFocusChanged { focused = it.isFocused },
+                )
+            }
         }
     }
 }
@@ -615,7 +722,7 @@ private fun DateField(label: String, value: String, onChange: (String) -> Unit) 
 private fun MultiSelectChips(options: List<FormChoice>, selected: Set<String>, onToggle: (String) -> Unit, tint: Color) {
     FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
         options.forEach { option ->
-            ChoicePill(label = option.label, selected = option.value in selected, tint = tint, onClick = { onToggle(option.value) })
+            ChoicePill(option.label, option.value in selected, tint) { onToggle(option.value) }
         }
     }
 }
@@ -633,9 +740,7 @@ private fun ChoicePill(label: String, selected: Boolean, tint: Color, onClick: (
             horizontalArrangement = Arrangement.spacedBy(6.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            if (selected) {
-                Icon(Icons.Outlined.Check, contentDescription = null, tint = Color.White, modifier = Modifier.size(15.dp))
-            }
+            if (selected) Icon(Icons.Outlined.Check, contentDescription = null, tint = Color.White, modifier = Modifier.size(15.dp))
             Text(
                 label,
                 color = if (selected) Color.White else MedtrackColors.InkSoft,
@@ -648,12 +753,8 @@ private fun ChoicePill(label: String, selected: Boolean, tint: Color, onClick: (
 
 @Composable
 private fun SegmentedToggle(options: List<Pair<String, String>>, selected: String, onSelect: (String) -> Unit) {
-    Surface(
-        shape = RoundedCornerShape(14.dp),
-        color = MedtrackColors.SurfaceAlt,
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Row(modifier = Modifier.padding(4.dp), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+    Surface(shape = RoundedCornerShape(14.dp), color = MedtrackColors.SurfaceAlt, modifier = Modifier.fillMaxWidth()) {
+        Row(Modifier.padding(4.dp), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
             options.forEach { (label, value) ->
                 val active = value == selected
                 Surface(
@@ -664,7 +765,7 @@ private fun SegmentedToggle(options: List<Pair<String, String>>, selected: Strin
                     color = if (active) MedtrackColors.Card else Color.Transparent,
                     border = if (active) BorderStroke(1.dp, MedtrackColors.Border) else null,
                 ) {
-                    Box(modifier = Modifier.padding(vertical = 10.dp), contentAlignment = Alignment.Center) {
+                    Box(Modifier.padding(vertical = 10.dp), contentAlignment = Alignment.Center) {
                         Text(
                             label,
                             color = if (active) MedtrackColors.Ink else MedtrackColors.Muted,
@@ -693,7 +794,7 @@ private fun ToggleRow(label: String, help: String, checked: Boolean, onChange: (
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
                 Text(label, color = MedtrackColors.Ink, fontWeight = FontWeight.Bold)
                 Text(help, color = MedtrackColors.Faint, style = MaterialTheme.typography.bodySmall)
             }
@@ -721,7 +822,7 @@ private fun BannerError(text: String) {
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(bottom = 4.dp),
+            .padding(start = 16.dp, end = 16.dp, top = 8.dp),
         shape = RoundedCornerShape(13.dp),
         color = MedtrackColors.DangerSoft,
         border = BorderStroke(1.dp, MedtrackColors.Danger.copy(alpha = 0.4f)),
@@ -739,7 +840,6 @@ private fun BannerError(text: String) {
 @Composable
 private fun BottomBar(
     primaryLabel: String,
-    primaryEnabled: Boolean,
     submitting: Boolean,
     showBack: Boolean,
     onBack: () -> Unit,
@@ -757,14 +857,14 @@ private fun BottomBar(
             if (showBack) {
                 Surface(
                     modifier = Modifier
-                        .height(52.dp)
+                        .size(52.dp)
                         .clickable(onClick = onBack),
                     shape = RoundedCornerShape(14.dp),
                     color = MedtrackColors.Card,
                     border = BorderStroke(1.dp, MedtrackColors.Border),
                 ) {
-                    Row(modifier = Modifier.padding(horizontal = 18.dp).fillMaxSize(), verticalAlignment = Alignment.CenterVertically) {
-                        Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Back", tint = MedtrackColors.InkSoft, modifier = Modifier.size(18.dp))
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Back", tint = MedtrackColors.InkSoft, modifier = Modifier.size(20.dp))
                     }
                 }
             }
@@ -772,11 +872,11 @@ private fun BottomBar(
                 modifier = Modifier
                     .weight(1f)
                     .height(52.dp)
-                    .clickable(enabled = primaryEnabled, onClick = onPrimary),
+                    .clickable(enabled = !submitting, onClick = onPrimary),
                 shape = RoundedCornerShape(14.dp),
-                color = if (primaryEnabled) MedtrackColors.Primary else MedtrackColors.Faint,
+                color = MedtrackColors.Primary,
             ) {
-                Row(modifier = Modifier.fillMaxSize(), horizontalArrangement = Arrangement.Center, verticalAlignment = Alignment.CenterVertically) {
+                Row(Modifier.fillMaxSize(), horizontalArrangement = Arrangement.Center, verticalAlignment = Alignment.CenterVertically) {
                     if (submitting) {
                         CircularProgressIndicator(color = Color.White, strokeWidth = 2.dp, modifier = Modifier.size(18.dp))
                     } else {
@@ -795,7 +895,7 @@ private fun Stepper(steps: List<String>, currentStep: Int) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(start = 16.dp, end = 16.dp, bottom = 12.dp),
+            .padding(start = 16.dp, end = 16.dp, bottom = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
@@ -886,14 +986,6 @@ private fun CenterState(title: String, subtitle: String?, onBack: () -> Unit, lo
         TextButton(onClick = onBack) { Text("Go back") }
     }
 }
-
-@Composable
-private fun fieldColors() = TextFieldDefaults.colors(
-    focusedContainerColor = MedtrackColors.Card,
-    unfocusedContainerColor = MedtrackColors.Card,
-    focusedIndicatorColor = MedtrackColors.Primary,
-    unfocusedIndicatorColor = MedtrackColors.Border,
-)
 
 private fun String?.handoffColor(): Color =
     when {

--- a/android/feature/case/src/main/java/com/naveenhospital/medtrack/feature/case/CaseCreationScreen.kt
+++ b/android/feature/case/src/main/java/com/naveenhospital/medtrack/feature/case/CaseCreationScreen.kt
@@ -377,12 +377,12 @@ private fun PathwayStep(state: CaseFormState) {
             category.name.isAnc() -> {
                 MedtrackSectionTitle(title = "Obstetric history (GPLA)")
                 FieldRow {
-                    StepperField("Gravida", state.gravida, { state.gravida = it }, Modifier.weight(1f))
-                    StepperField("Para", state.para, { state.para = it }, Modifier.weight(1f))
+                    StepperField("Gravida (G)", state.gravida, { state.gravida = it }, Modifier.weight(1f))
+                    StepperField("Para (P)", state.para, { state.para = it }, Modifier.weight(1f))
                 }
                 FieldRow {
-                    StepperField("Abortions", state.abortions, { state.abortions = it }, Modifier.weight(1f))
-                    StepperField("Living", state.living, { state.living = it }, Modifier.weight(1f))
+                    StepperField("Abortions (A)", state.abortions, { state.abortions = it }, Modifier.weight(1f))
+                    StepperField("Living (L)", state.living, { state.living = it }, Modifier.weight(1f))
                 }
                 FieldRow {
                     StepperField("FTND", state.ftnd, { state.ftnd = it }, Modifier.weight(1f))
@@ -500,8 +500,8 @@ private fun StatusMark(status: FieldStatus) {
     when (status) {
         FieldStatus.Needs -> Box(
             modifier = Modifier
-                .size(7.dp)
-                .background(MedtrackColors.Warning, CircleShape),
+                .size(6.dp)
+                .background(MedtrackColors.Warning.copy(alpha = 0.85f), CircleShape),
         )
         FieldStatus.Done -> Icon(
             Icons.Outlined.Check,
@@ -540,11 +540,11 @@ private fun FieldShell(
 ) {
     val borderColor = when {
         focused -> MedtrackColors.Primary
-        status == FieldStatus.Needs -> MedtrackColors.Warning.copy(alpha = 0.55f)
+        status == FieldStatus.Needs -> MedtrackColors.Warning.copy(alpha = 0.3f)
         else -> MedtrackColors.Border
     }
     val fill = if (status == FieldStatus.Needs && !focused) {
-        MedtrackColors.WarningSoft.copy(alpha = 0.5f)
+        MedtrackColors.WarningSoft.copy(alpha = 0.25f)
     } else {
         MedtrackColors.Card
     }
@@ -612,11 +612,11 @@ private fun MultilineField(
     val status = fieldStatus(required, value.isNotBlank())
     val borderColor = when {
         focused -> MedtrackColors.Primary
-        status == FieldStatus.Needs -> MedtrackColors.Warning.copy(alpha = 0.55f)
+        status == FieldStatus.Needs -> MedtrackColors.Warning.copy(alpha = 0.3f)
         else -> MedtrackColors.Border
     }
     val fill = if (status == FieldStatus.Needs && !focused) {
-        MedtrackColors.WarningSoft.copy(alpha = 0.5f)
+        MedtrackColors.WarningSoft.copy(alpha = 0.25f)
     } else {
         MedtrackColors.Card
     }

--- a/android/feature/case/src/main/java/com/naveenhospital/medtrack/feature/case/CaseFormState.kt
+++ b/android/feature/case/src/main/java/com/naveenhospital/medtrack/feature/case/CaseFormState.kt
@@ -1,0 +1,222 @@
+package com.naveenhospital.medtrack.feature.cases
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.naveenhospital.medtrack.core.domain.model.CaseCategory
+import com.naveenhospital.medtrack.core.domain.model.CaseFormCategory
+import com.naveenhospital.medtrack.core.domain.model.CaseFormMetadata
+import com.naveenhospital.medtrack.core.domain.model.NewCaseInput
+import com.naveenhospital.medtrack.core.domain.model.PatientLookup
+
+/** Mutable holder for the multi-step case-creation wizard. */
+class CaseFormState(
+    val metadata: CaseFormMetadata,
+    initialCategory: CaseCategory,
+) {
+    // Patient (new)
+    var patientMode by mutableStateOf("new")
+    var useTemporaryUhid by mutableStateOf(true)
+    var uhid by mutableStateOf("")
+    var prefix by mutableStateOf("")
+    var firstName by mutableStateOf("")
+    var lastName by mutableStateOf("")
+    var gender by mutableStateOf("")
+    var bloodGroup by mutableStateOf("")
+    var age by mutableStateOf("")
+    var phone by mutableStateOf("")
+    var place by mutableStateOf("")
+
+    // Patient (existing)
+    var patientQuery by mutableStateOf("")
+    var patientResults by mutableStateOf<List<PatientLookup>>(emptyList())
+    var searching by mutableStateOf(false)
+    var selectedPatient by mutableStateOf<PatientLookup?>(null)
+    var searchPatients: suspend (String) -> List<PatientLookup> = { emptyList() }
+
+    // Clinical
+    var category by mutableStateOf<CaseFormCategory?>(null)
+    var subcategory by mutableStateOf("")
+    var diagnosis by mutableStateOf("")
+    var referredBy by mutableStateOf("")
+    var notes by mutableStateOf("")
+    var highRisk by mutableStateOf(false)
+    var ncdFlags by mutableStateOf<Set<String>>(emptySet())
+
+    // ANC
+    var gravida by mutableStateOf<Int?>(null)
+    var para by mutableStateOf<Int?>(null)
+    var abortions by mutableStateOf<Int?>(null)
+    var living by mutableStateOf<Int?>(null)
+    var ftnd by mutableStateOf<Int?>(null)
+    var lscs by mutableStateOf<Int?>(null)
+    var lmp by mutableStateOf("")
+    var edd by mutableStateOf("")
+    var usgEdd by mutableStateOf("")
+    var rchNumber by mutableStateOf("")
+    var rchBypass by mutableStateOf(true)
+    var ancReasons by mutableStateOf<Set<String>>(emptySet())
+
+    // Surgery
+    var surgicalPathway by mutableStateOf("")
+    var surgeryDate by mutableStateOf("")
+
+    // Medicine
+    var reviewFrequency by mutableStateOf("")
+    var reviewDate by mutableStateOf("")
+
+    init {
+        val targetName = when (initialCategory) {
+            CaseCategory.ANC -> "ANC"
+            CaseCategory.SURGERY -> "Surgery"
+            CaseCategory.MEDICINE -> "Medicine"
+            else -> null
+        }
+        val initial = metadata.categories.firstOrNull { it.name.equals(targetName, ignoreCase = true) }
+            ?: metadata.categories.firstOrNull()
+        initial?.let { selectCategory(it) }
+    }
+
+    private fun CaseFormCategory.isAnc() = name.trim().equals("ANC", ignoreCase = true)
+    private fun CaseFormCategory.isSurgery() = name.trim().equals("Surgery", ignoreCase = true)
+
+    fun selectCategory(option: CaseFormCategory) {
+        category = option
+        subcategory = ""
+        if (option.isAnc() && gender.isBlank()) gender = "FEMALE"
+    }
+
+    fun selectPatient(patient: PatientLookup) {
+        selectedPatient = patient
+        patientResults = emptyList()
+        patientQuery = patient.name
+    }
+
+    fun toggleNcd(value: String) {
+        ncdFlags = if (value in ncdFlags) ncdFlags - value else ncdFlags + value
+    }
+
+    fun toggleAncReason(value: String) {
+        ancReasons = if (value in ancReasons) ancReasons - value else ancReasons + value
+    }
+
+    fun stepTitles(): List<String> {
+        val pathway = category?.let {
+            when {
+                it.isAnc() -> "ANC"
+                it.isSurgery() -> "Surgery"
+                else -> "Medicine"
+            }
+        } ?: "Medicine"
+        return listOf("Patient", "Clinical", pathway, "Review")
+    }
+
+    fun validateStep(title: String): String? {
+        val cat = category
+        return when (title) {
+            "Patient" -> when {
+                patientMode == "existing" && selectedPatient == null -> "Choose an existing patient."
+                patientMode == "new" && firstName.isBlank() -> "Enter the patient's first name."
+                patientMode == "new" && lastName.isBlank() -> "Enter the patient's last name."
+                patientMode == "new" && prefix.isBlank() -> "Choose a prefix."
+                patientMode == "new" && gender.isBlank() -> "Choose a sex."
+                patientMode == "new" && age.toIntOrNull() == null -> "Enter a valid age."
+                patientMode == "new" && phone.length != 10 -> "Enter a 10-digit phone number."
+                patientMode == "new" && !useTemporaryUhid && uhid.isBlank() -> "Enter a UHID or use a temporary ID."
+                else -> null
+            }
+            "Clinical" -> when {
+                cat == null -> "Choose a category."
+                cat.subcategories.isNotEmpty() && subcategory.isBlank() -> "Choose a subcategory."
+                diagnosis.isBlank() -> "Enter a diagnosis or reason."
+                else -> null
+            }
+            "ANC" -> when {
+                lmp.isBlank() -> "Enter the LMP date."
+                edd.isBlank() && usgEdd.isBlank() -> "Enter an EDD (LMP-based or USG)."
+                !rchBypass && rchNumber.isBlank() -> "Enter an RCH number or bypass it."
+                highRisk && ancReasons.isEmpty() -> "Select at least one high-risk reason."
+                else -> null
+            }
+            "Surgery" -> when {
+                surgicalPathway.isBlank() -> "Choose a surgical pathway."
+                surgicalPathway == "PLANNED_SURGERY" && surgeryDate.isBlank() -> "Enter the surgery date."
+                surgicalPathway == "SURVEILLANCE" && reviewDate.isBlank() -> "Enter the review date."
+                else -> null
+            }
+            "Medicine" -> when {
+                reviewDate.isBlank() -> "Enter a review date."
+                else -> null
+            }
+            else -> null
+        }
+    }
+
+    fun reviewPatientLine(): String {
+        return if (patientMode == "existing") {
+            selectedPatient?.let { "${it.name}  •  ${it.uhid}" } ?: "-"
+        } else {
+            val name = listOf(prefix, firstName, lastName).filter { it.isNotBlank() }.joinToString(" ")
+            val suffix = age.toIntOrNull()?.let { "  •  ${it}y" } ?: ""
+            (name.ifBlank { "New patient" }) + suffix
+        }
+    }
+
+    fun subcategoryLabel(): String? =
+        category?.subcategories?.firstOrNull { it.value == subcategory }?.label
+
+    fun pathwaySummary(): String? {
+        val cat = category ?: return null
+        return when {
+            cat.isAnc() -> "LMP ${lmp.ifBlank { "-" }}" + (if (edd.isNotBlank()) "  •  EDD $edd" else "")
+            cat.isSurgery() -> {
+                val label = metadata.surgicalPathways.firstOrNull { it.value == surgicalPathway }?.label ?: "-"
+                if (surgeryDate.isNotBlank()) "$label  •  $surgeryDate" else label
+            }
+            else -> "Review ${reviewDate.ifBlank { "-" }}"
+        }
+    }
+
+    fun toInput(): NewCaseInput {
+        val cat = category!!
+        val isAncCat = cat.isAnc()
+        return NewCaseInput(
+            patientMode = patientMode,
+            selectedPatientId = if (patientMode == "existing") selectedPatient?.id else null,
+            useTemporaryUhid = patientMode == "new" && useTemporaryUhid,
+            uhid = uhid.ifBlank { null },
+            prefix = prefix.ifBlank { null },
+            firstName = firstName.ifBlank { null },
+            lastName = lastName.ifBlank { null },
+            gender = gender.ifBlank { null },
+            bloodGroup = bloodGroup.ifBlank { null },
+            place = place.ifBlank { null },
+            age = age.toIntOrNull(),
+            phoneNumber = phone.ifBlank { null },
+            categoryId = cat.id,
+            categoryName = cat.name,
+            subcategory = subcategory.ifBlank { null },
+            diagnosis = diagnosis.ifBlank { null },
+            referredBy = referredBy.ifBlank { null },
+            notes = notes.ifBlank { null },
+            highRisk = highRisk,
+            ncdFlags = ncdFlags.toList(),
+            ancHighRiskReasons = if (isAncCat && highRisk) ancReasons.toList() else emptyList(),
+            rchNumber = if (isAncCat) rchNumber.ifBlank { null } else null,
+            rchBypass = isAncCat && rchBypass,
+            lmp = if (isAncCat) lmp.ifBlank { null } else null,
+            edd = if (isAncCat) edd.ifBlank { null } else null,
+            usgEdd = if (isAncCat) usgEdd.ifBlank { null } else null,
+            surgicalPathway = surgicalPathway.ifBlank { null },
+            surgeryDate = surgeryDate.ifBlank { null },
+            reviewFrequency = reviewFrequency.ifBlank { null },
+            reviewDate = reviewDate.ifBlank { null },
+            gravida = gravida,
+            para = para,
+            abortions = abortions,
+            living = living,
+            ftnd = ftnd,
+            lscs = lscs,
+        )
+    }
+}

--- a/api/tests.py
+++ b/api/tests.py
@@ -776,3 +776,274 @@ class FakeFirebaseMessaging:
             self.notification = notification
             self.data = data
             self.android = android
+
+
+class MobileCaseCreateTests(APITestCase):
+    def setUp(self):
+        from patients.models import Patient, ensure_default_departments
+
+        ensure_default_departments()
+        self.Patient = Patient
+        self.admin = get_user_model().objects.create_superuser(
+            username="create-admin",
+            email="create-admin@example.com",
+            password="pass",
+        )
+        self.client.force_authenticate(self.admin)
+        self.anc = DepartmentConfig.objects.get(name="ANC")
+        self.surgery = DepartmentConfig.objects.get(name="Surgery")
+        self.medicine = DepartmentConfig.objects.get(name="Medicine")
+
+    def _post_create(self, payload):
+        return self.client.post(reverse("api:case_list"), payload, format="json")
+
+    def test_create_new_anc_case_seeds_tasks_and_rch_reminder(self):
+        payload = {
+            "patient_mode": "new",
+            "use_temporary_uhid": True,
+            "prefix": "MRS",
+            "first_name": "Keerthana",
+            "last_name": "Manikandan",
+            "gender": "FEMALE",
+            "age": 27,
+            "phone_number": "9876500000",
+            "category": self.anc.id,
+            "diagnosis": "Antenatal follow-up",
+            "high_risk": False,
+            "rch_bypass": True,
+            "lmp": (timezone.localdate() - timedelta(days=60)).isoformat(),
+            "edd": (timezone.localdate() + timedelta(days=220)).isoformat(),
+            "gravida": 1,
+            "para": 0,
+            "abortions": 0,
+            "living": 0,
+            "client_write_id": "anc-create-1",
+        }
+
+        response = self._post_create(payload)
+
+        self.assertEqual(response.status_code, 201, response.content)
+        body = response.json()
+        case_id = body["case_id"]
+        case = Case.objects.get(pk=case_id)
+        self.assertEqual(case.category_id, self.anc.id)
+        self.assertEqual(case.first_name, "Keerthana")
+        self.assertTrue(case.patient.is_temporary_id)
+        self.assertTrue(case.uhid.startswith("TMP-"))
+        self.assertGreaterEqual(case.tasks.count(), 1)
+        self.assertTrue(case.tasks.filter(title="Update RCH Number").exists())
+
+    def test_create_new_surgery_case_with_subcategory_and_pathway(self):
+        surgery_date = (timezone.localdate() + timedelta(days=20)).isoformat()
+        payload = {
+            "patient_mode": "new",
+            "use_temporary_uhid": True,
+            "prefix": "MR",
+            "first_name": "Arun",
+            "last_name": "Kumar",
+            "gender": "MALE",
+            "age": 45,
+            "phone_number": "9876500001",
+            "category": self.surgery.id,
+            "subcategory": "GENERAL_SURGERY",
+            "diagnosis": "Hernia",
+            "surgical_pathway": "PLANNED_SURGERY",
+            "surgery_date": surgery_date,
+            "client_write_id": "surgery-create-1",
+        }
+
+        response = self._post_create(payload)
+
+        self.assertEqual(response.status_code, 201, response.content)
+        case = Case.objects.get(pk=response.json()["case_id"])
+        self.assertEqual(case.subcategory, "GENERAL_SURGERY")
+        self.assertEqual(case.surgical_pathway, "PLANNED_SURGERY")
+        self.assertGreaterEqual(case.tasks.count(), 1)
+
+    def test_create_new_medicine_case_with_review(self):
+        review_date = (timezone.localdate() + timedelta(days=30)).isoformat()
+        payload = {
+            "patient_mode": "new",
+            "use_temporary_uhid": True,
+            "prefix": "MR",
+            "first_name": "Suresh",
+            "last_name": "Raina",
+            "gender": "MALE",
+            "age": 60,
+            "phone_number": "9876500002",
+            "category": self.medicine.id,
+            "subcategory": "GENERAL_MEDICINE",
+            "diagnosis": "T2DM review",
+            "review_frequency": "MONTHLY",
+            "review_date": review_date,
+            "client_write_id": "medicine-create-1",
+        }
+
+        response = self._post_create(payload)
+
+        self.assertEqual(response.status_code, 201, response.content)
+        case = Case.objects.get(pk=response.json()["case_id"])
+        self.assertEqual(case.review_frequency, "MONTHLY")
+        self.assertIsNotNone(case.review_date)
+
+    def test_create_existing_patient_case_reuses_patient(self):
+        first = self._post_create(
+            {
+                "patient_mode": "new",
+                "use_temporary_uhid": True,
+                "prefix": "MR",
+                "first_name": "Vikram",
+                "last_name": "Singh",
+                "gender": "MALE",
+                "age": 50,
+                "phone_number": "9876500003",
+                "category": self.medicine.id,
+                "subcategory": "GENERAL_MEDICINE",
+                "diagnosis": "HTN",
+                "review_date": (timezone.localdate() + timedelta(days=30)).isoformat(),
+                "client_write_id": "existing-1",
+            }
+        )
+        self.assertEqual(first.status_code, 201, first.content)
+        patient = Case.objects.get(pk=first.json()["case_id"]).patient
+
+        second = self._post_create(
+            {
+                "patient_mode": "existing",
+                "selected_patient": patient.id,
+                "category": self.surgery.id,
+                "subcategory": "ORTHOPEDICS",
+                "diagnosis": "Knee",
+                "surgical_pathway": "SURVEILLANCE",
+                "review_date": (timezone.localdate() + timedelta(days=15)).isoformat(),
+                "client_write_id": "existing-2",
+            }
+        )
+
+        self.assertEqual(second.status_code, 201, second.content)
+        new_case = Case.objects.get(pk=second.json()["case_id"])
+        self.assertEqual(new_case.patient_id, patient.id)
+        self.assertEqual(self.Patient.objects.filter(pk=patient.id).count(), 1)
+
+    def test_create_validation_error_returns_field_errors(self):
+        response = self._post_create(
+            {
+                "patient_mode": "new",
+                "category": self.anc.id,
+                "client_write_id": "bad-1",
+            }
+        )
+
+        self.assertEqual(response.status_code, 400)
+        errors = response.json()["errors"]
+        self.assertIn("first_name", errors)
+
+    def test_create_is_idempotent_on_client_write_id(self):
+        payload = {
+            "patient_mode": "new",
+            "use_temporary_uhid": True,
+            "prefix": "MRS",
+            "first_name": "Divya",
+            "last_name": "Nair",
+            "gender": "FEMALE",
+            "age": 30,
+            "phone_number": "9876500004",
+            "category": self.anc.id,
+            "diagnosis": "ANC",
+            "rch_bypass": True,
+            "lmp": (timezone.localdate() - timedelta(days=60)).isoformat(),
+            "edd": (timezone.localdate() + timedelta(days=220)).isoformat(),
+            "gravida": 1,
+            "para": 0,
+            "abortions": 0,
+            "living": 0,
+            "client_write_id": "idem-1",
+        }
+
+        first = self._post_create(payload)
+        second = self._post_create(payload)
+
+        self.assertEqual(first.status_code, 201, first.content)
+        self.assertEqual(second.status_code, 201, second.content)
+        self.assertEqual(first.json()["case_id"], second.json()["case_id"])
+        self.assertEqual(Case.objects.filter(first_name="Divya").count(), 1)
+
+    def test_create_denied_without_case_create_capability(self):
+        group = Group.objects.create(name="ReadOnlyRole")
+        RoleSetting.objects.create(role_name="ReadOnlyRole", can_note_add=True, can_case_create=False)
+        viewer = get_user_model().objects.create_user(username="viewer", password="pass")
+        viewer.groups.add(group)
+        client = APIClient()
+        client.force_authenticate(viewer)
+
+        response = client.post(
+            reverse("api:case_list"),
+            {
+                "patient_mode": "new",
+                "use_temporary_uhid": True,
+                "prefix": "MR",
+                "first_name": "No",
+                "last_name": "Access",
+                "gender": "MALE",
+                "age": 40,
+                "phone_number": "9876500005",
+                "category": self.medicine.id,
+                "subcategory": "GENERAL_MEDICINE",
+                "diagnosis": "x",
+                "review_date": (timezone.localdate() + timedelta(days=30)).isoformat(),
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_patient_search_finds_created_patient(self):
+        self._post_create(
+            {
+                "patient_mode": "new",
+                "use_temporary_uhid": True,
+                "prefix": "MRS",
+                "first_name": "Lakshmi",
+                "last_name": "Devi",
+                "gender": "FEMALE",
+                "age": 33,
+                "phone_number": "9876512345",
+                "category": self.anc.id,
+                "diagnosis": "ANC",
+                "rch_bypass": True,
+                "lmp": (timezone.localdate() - timedelta(days=60)).isoformat(),
+                "edd": (timezone.localdate() + timedelta(days=220)).isoformat(),
+                "gravida": 1,
+                "para": 0,
+                "abortions": 0,
+                "living": 0,
+                "client_write_id": "search-seed",
+            }
+        )
+
+        response = self.client.get(reverse("api:patient_search"), {"q": "Lakshmi"})
+
+        self.assertEqual(response.status_code, 200)
+        results = response.json()["results"]
+        self.assertTrue(any(row["first_name"] == "Lakshmi" for row in results))
+
+    def test_case_form_metadata_returns_choice_lists(self):
+        response = self.client.get(reverse("api:case_form_metadata"))
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertTrue(body["can_create"])
+        for key in [
+            "categories",
+            "prefixes",
+            "blood_groups",
+            "genders",
+            "ncd_flags",
+            "anc_high_risk_reasons",
+            "surgical_pathways",
+            "review_frequencies",
+        ]:
+            self.assertIn(key, body)
+            self.assertTrue(body[key])
+        self.assertIn("value", body["prefixes"][0])
+        self.assertIn("label", body["prefixes"][0])

--- a/api/urls.py
+++ b/api/urls.py
@@ -4,6 +4,7 @@ from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from .views import (
     CallOutcomeView,
     CaseDetailView,
+    CaseFormMetadataView,
     CaseListView,
     CaseVitalsView,
     CategoryMetadataView,
@@ -12,6 +13,7 @@ from .views import (
     MeView,
     NotificationReadView,
     NotificationsView,
+    PatientSearchView,
     TaskCompleteView,
     VitalsThresholdsView,
 )
@@ -24,6 +26,7 @@ urlpatterns = [
     path("auth/logout/", LogoutView.as_view(), name="logout"),
     path("me/", MeView.as_view(), name="me"),
     path("cases/", CaseListView.as_view(), name="case_list"),
+    path("patients/", PatientSearchView.as_view(), name="patient_search"),
     path("cases/<int:pk>/", CaseDetailView.as_view(), name="case_detail"),
     path("cases/<int:pk>/call-outcome/", CallOutcomeView.as_view(), name="case_call_outcome"),
     path("cases/<int:pk>/vitals/", CaseVitalsView.as_view(), name="case_vitals"),
@@ -33,4 +36,5 @@ urlpatterns = [
     path("notifications/", NotificationsView.as_view(), name="notifications"),
     path("notifications/<int:pk>/read/", NotificationReadView.as_view(), name="notification_read"),
     path("metadata/categories/", CategoryMetadataView.as_view(), name="category_metadata"),
+    path("metadata/case-form/", CaseFormMetadataView.as_view(), name="case_form_metadata"),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -1,4 +1,5 @@
 import json
+from datetime import timedelta
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import transaction
@@ -14,18 +15,30 @@ from rest_framework_simplejwt.tokens import RefreshToken
 
 from patients.models import (
     ActivityEventType,
+    AncHighRiskReason,
+    BloodGroup,
     CallLog,
     Case,
     CaseActivityLog,
+    CasePrefix,
     CaseStatus,
     DepartmentConfig,
+    Gender,
+    NonCommunicableDisease,
+    Patient,
+    ReviewFrequency,
+    SurgicalPathway,
     Task,
     TaskStatus,
     VitalEntry,
+    build_default_tasks,
     case_subcategory_choices_for_category_name,
+    ensure_rch_reminder_task,
+    frequency_to_days,
 )
 from patients.theme import build_theme_category_colors, resolve_category_theme
 from patients.vitals_thresholds import vitals_thresholds_payload
+from patients.forms import CaseForm
 from patients.views import (
     CASE_CATEGORY_GROUP_FILTERS,
     _blood_pressure_display,
@@ -35,6 +48,7 @@ from patients.views import (
     _dashboard_category_icon_path,
     _dashboard_subcategory_icon_path,
     _display_user_name,
+    _patient_search_queryset,
     _visible_case_queryset,
     _visible_task_queryset,
     can_access_case_data,
@@ -47,6 +61,7 @@ from .models import MobileDeviceToken, MobileNotification, MobileWriteReceipt
 from .permissions import HasMobileCaseAccess
 from .serializers import (
     CallOutcomeSerializer,
+    ClientWriteSerializer,
     DeviceTokenSerializer,
     LogoutSerializer,
     TaskCompleteSerializer,
@@ -351,6 +366,55 @@ class CaseListView(APIView):
             }
         )
 
+    def post(self, request):
+        if not has_capability(request.user, "case_create"):
+            return Response(
+                {"message": "You do not have permission to create cases."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        write_serializer = ClientWriteSerializer(data=request.data)
+        write_serializer.is_valid(raise_exception=True)
+
+        form = CaseForm(data=request.data)
+        form.actor = request.user
+        form.instance.created_by = request.user
+        if not form.is_valid():
+            return Response(
+                {"message": "Please fix the highlighted fields.", "errors": _form_errors(form)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        def apply_write():
+            with transaction.atomic():
+                case = form.save()
+                if case.review_frequency and not case.review_date:
+                    case.review_date = timezone.localdate() + timedelta(
+                        days=frequency_to_days(case.review_frequency)
+                    )
+                    case.save(update_fields=["review_date", "updated_at", "patient_name"])
+                created_tasks = build_default_tasks(case, request.user)
+                create_case_activity(
+                    case=case,
+                    user=request.user,
+                    event_type=ActivityEventType.SYSTEM,
+                    note=f"Case created from mobile with {len(created_tasks)} starter task(s)",
+                )
+                ensure_rch_reminder_task(case, request.user)
+            return {
+                "message": "Case created.",
+                "case_id": case.id,
+                "case": _mobile_case_payload(case, user=request.user),
+            }, status.HTTP_201_CREATED
+
+        return _idempotent_response(request, write_serializer, "case_create", apply_write)
+
+
+def _form_errors(form):
+    return {
+        field: [str(error) for error in errors]
+        for field, errors in form.errors.items()
+    }
+
 
 class CaseDetailView(APIView):
     permission_classes = [HasMobileCaseAccess]
@@ -604,30 +668,95 @@ class NotificationReadView(APIView):
         )
 
 
+def _category_metadata_payload():
+    categories = list(DepartmentConfig.objects.order_by("name"))
+    theme_category_colors = build_theme_category_colors(categories)
+    return [
+        {
+            "id": category.id,
+            "name": category.name,
+            "icon_path": _dashboard_category_icon_path(category.name),
+            "theme": resolve_category_theme(theme_category_colors, category),
+            "subcategories": [
+                {
+                    "value": value,
+                    "label": label,
+                    "icon_path": _dashboard_subcategory_icon_path(value),
+                }
+                for value, label in case_subcategory_choices_for_category_name(category.name)
+            ],
+        }
+        for category in categories
+    ]
+
+
+def _choice_payload(choices):
+    return [{"value": value, "label": str(label)} for value, label in choices]
+
+
 class CategoryMetadataView(APIView):
     permission_classes = [HasMobileCaseAccess]
 
     def get(self, request):
-        categories = list(DepartmentConfig.objects.order_by("name"))
-        theme_category_colors = build_theme_category_colors(categories)
+        return Response({"categories": _category_metadata_payload()})
+
+
+class CaseFormMetadataView(APIView):
+    """Everything the mobile case-creation wizard needs to render its menus."""
+
+    permission_classes = [HasMobileCaseAccess]
+
+    def get(self, request):
         return Response(
             {
-                "categories": [
-                    {
-                        "id": category.id,
-                        "name": category.name,
-                        "icon_path": _dashboard_category_icon_path(category.name),
-                        "theme": resolve_category_theme(theme_category_colors, category),
-                        "subcategories": [
-                            {
-                                "value": value,
-                                "label": label,
-                                "icon_path": _dashboard_subcategory_icon_path(value),
-                            }
-                            for value, label in case_subcategory_choices_for_category_name(category.name)
-                        ],
-                    }
-                    for category in categories
-                ]
+                "can_create": has_capability(request.user, "case_create"),
+                "categories": _category_metadata_payload(),
+                "prefixes": _choice_payload(CasePrefix.choices),
+                "blood_groups": _choice_payload(BloodGroup.choices),
+                "genders": _choice_payload(Gender.choices),
+                "ncd_flags": _choice_payload(NonCommunicableDisease.choices),
+                "anc_high_risk_reasons": _choice_payload(AncHighRiskReason.choices),
+                "surgical_pathways": _choice_payload(SurgicalPathway.choices),
+                "review_frequencies": _choice_payload(ReviewFrequency.choices),
+            }
+        )
+
+
+def _serialize_patient_row(patient):
+    return {
+        "id": patient.id,
+        "uhid": patient.uhid,
+        "name": patient.patient_name or patient.full_name,
+        "prefix": patient.prefix,
+        "first_name": patient.first_name,
+        "last_name": patient.last_name,
+        "gender": patient.gender,
+        "gender_label": patient.get_gender_display() if patient.gender else "",
+        "blood_group": patient.blood_group,
+        "date_of_birth": patient.date_of_birth.isoformat() if patient.date_of_birth else None,
+        "age": patient.age,
+        "place": patient.place,
+        "phone_number": patient.phone_number,
+        "alternate_phone_number": patient.alternate_phone_number,
+        "is_temporary_id": patient.is_temporary_id,
+        "active_case_count": getattr(patient, "active_case_count", None),
+        "total_case_count": getattr(patient, "total_case_count", None),
+    }
+
+
+class PatientSearchView(APIView):
+    permission_classes = [HasMobileCaseAccess]
+
+    def get(self, request):
+        query = request.GET.get("q", "").strip()
+        queryset = _patient_search_queryset(query)
+        paginator = MobilePagination()
+        page = paginator.paginate_queryset(queryset, request, view=self)
+        return Response(
+            {
+                "count": paginator.page.paginator.count,
+                "next": paginator.get_next_link(),
+                "previous": paginator.get_previous_link(),
+                "results": [_serialize_patient_row(patient) for patient in page],
             }
         )


### PR DESCRIPTION
## What & why

The Android app's "new case" screen was a **non-functional mock** — prefilled dummy data, a "Create mock case" button, and no backend endpoint behind it. This PR makes mobile case creation **real and at full parity with the web `CaseForm`**, reusing the web's own validation and task-seeding so the two stay in sync.

## Backend (DRF)

Reuses the web's logic rather than re-implementing it, so mobile inherits all validation + starter-task seeding for free.

- **`POST /api/cases/`** — builds the real `CaseForm`, runs the same `form_valid` path as the web (`build_default_tasks`, RCH reminder, review-date derivation). Idempotent via `client_write_id`, gated by the `case_create` capability, returns the mobile case payload, and maps `form.errors` to a structured 400.
- **`GET /api/patients/?q=`** — patient search for "existing patient" mode (reuses `_patient_search_queryset`).
- **`GET /api/metadata/case-form/`** — categories/subcategories **plus** every menu's choices (prefix, blood group, gender, NCD, ANC high-risk reasons, surgical pathway, review frequency) so the mobile form never drifts from the server.
- Tests for ANC/Surgery/Medicine creation, existing-patient reuse, validation errors, idempotency, capability gating, patient search, and metadata. **Full `api` suite passes (52 tests).**

No DB migration — it reuses existing models/forms.

## Android

A fresh, design-system-consistent **multi-step wizard** (Patient → Clinical → category pathway → Review) replacing the mock:

- New/existing patient modes (with live patient search), temporary-UHID toggle, server-driven dropdowns.
- Category-specific steps: **ANC** GPLA + LMP/EDD/USG + RCH bypass/number + high-risk reasons; **Surgery** pathway + date; **Medicine** review schedule.
- GPLA captured with **+/− steppers** (Gravida (G), Para (P), …) like the web.
- Online-only submit that parses server field errors; on success navigates to the created case's detail.
- The quick-add **FAB is hidden** when the user lacks `case_create`.
- Quick-add sheet reworked into a clean vertical list.
- A subtle, modern **required-field hint** (soft amber tint + dot that turns into a green check once filled) instead of asterisks.

## Verification

Built green and exercised end-to-end on an emulator against a local server running this branch: walked Patient → Clinical → ANC → Review → Create and confirmed a real case is created with its full ANC starter-task workflow seeded, landing on the case detail.

## Reviewer notes

- The Android **debug** build points at `http://10.0.2.2:8000`; **release** points at the VPS (`https://book.naveenhospital.net/`). To exercise the flow locally, run the Django server from this branch (the new endpoints don't exist on older builds).
- Mobile create is **online-only** by design (the server assigns the real case id/UHID and seeds tasks immediately); vitals/calls keep their existing offline queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
