### PR TITLE
Fix: mobile case edit erases patient DOB / alternate phone

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -1143,6 +1143,65 @@ class MobileEditApiTests(APITestCase):
         )
         self.assertEqual(response.status_code, 403)
 
+    def test_case_patch_preserves_omitted_patient_fields(self):
+        from datetime import date
+
+        from patients.models import Patient
+
+        dob = date(1994, 5, 1)
+        patient = Patient.objects.create(
+            uhid="UH-DOB-1",
+            prefix="MRS",
+            first_name="Asha",
+            last_name="Verma",
+            gender="FEMALE",
+            date_of_birth=dob,
+            phone_number="9811100000",
+            alternate_phone_number="9000000001",
+            created_by=self.admin,
+        )
+        case = Case.objects.create(
+            uhid="UH-DOB-1",
+            patient=patient,
+            prefix="MRS",
+            first_name="Asha",
+            last_name="Verma",
+            patient_name="Asha Verma",
+            gender="FEMALE",
+            date_of_birth=dob,
+            phone_number="9811100000",
+            alternate_phone_number="9000000001",
+            category=self.medicine,
+            subcategory="GENERAL_MEDICINE",
+            diagnosis="Review",
+            review_date=timezone.localdate() + timedelta(days=10),
+            created_by=self.admin,
+        )
+        # Mobile-style payload: the wizard never sends date_of_birth / alternate_phone_number.
+        payload = {
+            "patient_mode": "existing",
+            "uhid": case.uhid,
+            "prefix": "MRS",
+            "first_name": "Asha",
+            "last_name": "Verma",
+            "gender": "FEMALE",
+            "age": 31,
+            "phone_number": "9811100000",
+            "category": self.medicine.id,
+            "subcategory": "GENERAL_MEDICINE",
+            "status": "ACTIVE",
+            "diagnosis": "Review updated",
+            "review_date": (timezone.localdate() + timedelta(days=20)).isoformat(),
+        }
+        response = self.client.patch(
+            reverse("api:case_detail", args=[case.id]), payload, format="json"
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        patient.refresh_from_db()
+        # Fields the mobile edit omitted must survive, not be wiped.
+        self.assertEqual(patient.date_of_birth, dob)
+        self.assertEqual(patient.alternate_phone_number, "9000000001")
+
     # --- Task metadata + create ---
     def test_task_form_metadata(self):
         response = self.client.get(reverse("api:task_form_metadata"))

--- a/api/views.py
+++ b/api/views.py
@@ -465,7 +465,15 @@ class CaseDetailView(APIView):
             _visible_case_queryset(Case.objects.select_related("category", "patient")), pk=pk
         )
         old_status = case.status
-        form = CaseForm(data=request.data, instance=case)
+        # The mobile wizard does not expose every patient identity field, so backfill the
+        # ones it omits from the existing record. Without this, a mobile edit would submit a
+        # full CaseForm without date_of_birth / alternate_phone_number and erase them.
+        data = request.data.copy()
+        if not data.get("date_of_birth") and case.date_of_birth:
+            data["date_of_birth"] = case.date_of_birth.isoformat()
+        if not data.get("alternate_phone_number") and case.alternate_phone_number:
+            data["alternate_phone_number"] = case.alternate_phone_number
+        form = CaseForm(data=data, instance=case)
         form.actor = request.user
         if not form.is_valid():
             return Response(


### PR DESCRIPTION
## Problem (P2, from PR #82 automated review)

The mobile case-edit wizard does not surface every patient identity field. When a case has a **date of birth** or **alternate phone number**, the edit-form payload carries those values to the device but the wizard state drops them, so saving *any* unrelated edit from Android submitted a full `CaseForm` **without** `date_of_birth` / `alternate_phone_number`. `CaseForm` then rewrote the linked patient with empty values, **erasing the patient's DOB and alternate phone** on the server.

## Fix

`CaseDetailView.patch` now backfills `date_of_birth` and `alternate_phone_number` from the existing case when the request omits them, before binding `CaseForm`. This preserves the data for **any** client (not just this wizard) and keeps `CaseForm` as the single source of validation.

## Test

New regression test `test_case_patch_preserves_omitted_patient_fields`: builds a patient with a DOB + alternate phone, sends a mobile-style edit payload that omits both, and asserts they remain intact after save. Full `MobileEditApiTests` suite green (**15 tests**).

Note: the same omission was harmless for other patient fields because the wizard does send them; DOB and alternate phone were the only two it never sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)