### PR TITLE
Allow explicit clearing of patient DOB / alternate phone on case edit

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -1202,6 +1202,18 @@ class MobileEditApiTests(APITestCase):
         self.assertEqual(patient.date_of_birth, dob)
         self.assertEqual(patient.alternate_phone_number, "9000000001")
 
+        # An explicit blank is an intentional clear and must NOT be backfilled.
+        clear_payload = dict(payload)
+        clear_payload["alternate_phone_number"] = ""
+        clear_payload["date_of_birth"] = ""
+        response = self.client.patch(
+            reverse("api:case_detail", args=[case.id]), clear_payload, format="json"
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        patient.refresh_from_db()
+        self.assertEqual(patient.alternate_phone_number, "")
+        self.assertIsNone(patient.date_of_birth)
+
     # --- Task metadata + create ---
     def test_task_form_metadata(self):
         response = self.client.get(reverse("api:task_form_metadata"))

--- a/api/views.py
+++ b/api/views.py
@@ -468,10 +468,12 @@ class CaseDetailView(APIView):
         # The mobile wizard does not expose every patient identity field, so backfill the
         # ones it omits from the existing record. Without this, a mobile edit would submit a
         # full CaseForm without date_of_birth / alternate_phone_number and erase them.
+        # Only backfill when the key is ABSENT — an explicit blank ("") is treated as an
+        # intentional clear so the field can still be removed via the API.
         data = request.data.copy()
-        if not data.get("date_of_birth") and case.date_of_birth:
+        if "date_of_birth" not in data and case.date_of_birth:
             data["date_of_birth"] = case.date_of_birth.isoformat()
-        if not data.get("alternate_phone_number") and case.alternate_phone_number:
+        if "alternate_phone_number" not in data and case.alternate_phone_number:
             data["alternate_phone_number"] = case.alternate_phone_number
         form = CaseForm(data=data, instance=case)
         form.actor = request.user


### PR DESCRIPTION
## Context

Follow-up to PR #83. That PR merged the data-loss fix (backfilling `date_of_birth` / `alternate_phone_number` so a mobile edit can't erase them), but was merged **before** this refinement landed — so this small change didn't make it into `main`.

## What

PR #83's automated review noted that the backfill check (`if not data.get(...)`) also restored the old value when a client sent an explicit blank `""`, making it impossible to ever *clear* a wrong DOB or alternate phone via the API.

This changes the guard to backfill **only when the key is absent** (`"date_of_birth" not in data`):
- App omits the field → still backfilled (the #83 data-loss fix is unchanged).
- Client sends `""` → treated as an intentional clear and passed through to `CaseForm`.

## Test

Extends `test_case_patch_preserves_omitted_patient_fields` to also assert that sending `""` clears the field. Full `MobileEditApiTests` suite green (15 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)